### PR TITLE
[Comment] 댓글 논리 삭제, 물리삭제 기능 구현 및 테스트코드 작성

### DIFF
--- a/src/main/java/com/monew/monew_server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/monew/monew_server/domain/comment/controller/CommentController.java
@@ -77,4 +77,30 @@ public class CommentController {
         return ResponseEntity.ok(updatedComment);
     }
 
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable UUID commentId,
+            @RequestHeader("Monew-Request-User-ID") UUID userId
+    ) {
+        log.info("DELETE /api/comments/{} - 논리 삭제 요청, userId={}", commentId, userId);
+
+        commentService.deleteComment(commentId, userId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{commentId}/hard")
+    public ResponseEntity<Void> deleteHardComment(
+            @PathVariable UUID commentId,
+            @RequestHeader("Monew-Request-User-ID") UUID userId
+    ) {
+        log.info("DELETE /api/comments/{}/hard - 물리 삭제 요청, userId={}", commentId, userId);
+
+        commentService.hardDeleteComment(commentId, userId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+
+
 }

--- a/src/test/java/com/monew/monew_server/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/monew/monew_server/domain/comment/controller/CommentControllerTest.java
@@ -20,9 +20,11 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -164,7 +166,43 @@ class CommentControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].content").value("첫번째 댓글입니다"))
-                                .andExpect(jsonPath("$[0].likeCount").value(5));
+                .andExpect(jsonPath("$[0].likeCount").value(5));
+    }
+
+
+
+    // 댓글 삭제 테스트코드
+    @Test
+    @DisplayName("DELETE /api/comments/{commentId} - 댓글 논리 삭제 성공")
+    void deleteComment_Success() throws Exception {
+        // Given: 테스트 데이터 준비
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // Service Mock 설정: void 메서드는 아무것도 반환하지 않음
+        willDoNothing().given(commentService).deleteComment(eq(commentId), eq(userId));
+
+        // When & Then: HTTP DELETE 요청 + 검증
+        mockMvc.perform(delete("/api/comments/{commentId}", commentId)
+                        .header("Monew-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isNoContent());  // 204 검증
+    }
+    @Test
+    @DisplayName("DELETE /api/comments/{commentId}/hard - 댓글 물리 삭제 성공")
+    void hardDeleteComment_Success() throws Exception {
+        // Given: 테스트 데이터 준비
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // Service Mock 설정
+        willDoNothing().given(commentService).hardDeleteComment(eq(commentId), eq(userId));
+
+        // When & Then: HTTP DELETE 요청 + 검증
+        mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId)
+                        .header("Monew-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isNoContent());
     }
 
 }


### PR DESCRIPTION
  delete and test
  댓글 물리삭제, 논리삭제 기능 구현과
  ControllerTest 테스트 코드를 추가했습니다.

  - Swagger API 명세에 정의된 댓글 삭제 기능 구현
  - DELETE /api/comments/{commentId} 엔드포인트 추가
  - 삭제된 댓글 수정 방지 및 본인 확인 로직 구현

  추가사항 :
  - Swagger UI에서 수동 테스트 완료
  - Postman 을 이용한 댓글 정상 삭제 기능 확인

## PR 요약
<!-- 이번 PR의 목적과 변경 사항을 간단히 작성해주세요.-->


## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#24 )
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
<!-- 변경 사항, 추가된 기능, 버그 수정 내용 등을 자세히 작성해주세요.-->


## 검증 단계
<!-- 
PR을 적용하기 전에 확인한 사항과 테스트 방법을 작성해주세요.
예시:
1. 로컬 서버 실행 후 API 정상 동작 확인
2. 신규 기능 UI/UX 테스트 완료
3. 기존 기능 회귀 테스트 완료
-->


## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->
