### PR TITLE
[articles] 뉴스 기사 물리 삭제

### DIFF
--- a/src/main/java/com/monew/monew_server/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/monew/monew_server/domain/article/controller/ArticleController.java
@@ -89,6 +89,12 @@ public class ArticleController {
 	@DeleteMapping("/{articleId}")
 	public ResponseEntity<Void> softDeleteArticle(@PathVariable UUID articleId) {
 		articleService.softDeleteArticle(articleId);
-		return ResponseEntity.ok().build();
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping("/{articleId}/hard")
+	public ResponseEntity<Void> hardDeleteArticle(@PathVariable UUID articleId) {
+		articleService.hardDeleteArticle(articleId);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/monew/monew_server/domain/article/service/ArticleService.java
+++ b/src/main/java/com/monew/monew_server/domain/article/service/ArticleService.java
@@ -186,4 +186,12 @@ public class ArticleService {
 		article.softDelete();
 		articleRepository.save(article);
 	}
+
+	@Transactional
+	public void hardDeleteArticle(UUID articleId) {
+		Article article = articleRepository.findById(articleId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND));
+
+		articleRepository.delete(article);
+	}
 }


### PR DESCRIPTION
## PR 요약
기사 단건 물리 삭제(Hard Delete) 기능을 구현했습니다. `/api/articles/{articleId}/hard` 엔드포인트를 통해 요청 시 실제 데이터베이스에서 기사를 삭제하도록 변경했습니다.

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#42 )
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료

## 상세 설명
- `ArticleService#hardDeleteArticle(UUID articleId)`에서 존재 확인 후 `articleRepository.delete(article)` 호출
- 삭제 후 단건 조회 및 목록 조회에서 해당 기사 조회 불가
- Controller 엔드포인트: `DELETE /api/articles/{articleId}/hard`
- 삭제 성공 시 HTTP 204 No Content 반환

## 검증 단계
1. 로컬 서버 실행 후 `DELETE /api/articles/{articleId}/hard` 호출
2. 삭제된 기사 단건 조회 시 `ArticleNotFoundException` 발생 확인
3. 기사 목록 조회 시 삭제된 기사 제외 확인

## 추가 코멘트
- 데이터 제거 시 사용