### PR TITLE
feat(Comment): Add comment list, like feature and test

### DIFF
--- a/src/main/java/com/monew/monew_server/domain/comment/dto/CommentLikeDto.java
+++ b/src/main/java/com/monew/monew_server/domain/comment/dto/CommentLikeDto.java
@@ -1,0 +1,28 @@
+package com.monew.monew_server.domain.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentLikeDto {
+
+    private UUID id;
+    private UUID likedBy;
+    private Instant createdAt;
+
+    private UUID commentId;
+    private UUID articleId;
+    private UUID commentUserId;
+    private String commentUserNickname;
+    private String commentContent;
+    private Long commentLikeCount;
+    private Instant commentCreatedAt;
+}

--- a/src/main/java/com/monew/monew_server/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/monew/monew_server/domain/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,31 @@
+package com.monew.monew_server.domain.comment.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.monew.monew_server.domain.comment.entity.CommentLike;
+
+@Repository
+public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> {
+
+    Optional<CommentLike> findByComment_IdAndUser_Id(UUID commentId, UUID userId);
+
+    @Query("SELECT cl FROM CommentLike cl WHERE cl.comment.id IN :commentIds AND cl.user.id = :userId")
+    List<CommentLike> findByCommentIdsAndUserId(
+        @Param("commentIds") List<UUID> commentIds,
+        @Param("userId") UUID userId
+    );
+
+    long countByComment_Id(UUID commentId);
+
+    @Query("SELECT cl.comment.id, COUNT(cl) FROM CommentLike cl " +
+           "WHERE cl.comment.id IN :commentIds " +
+           "GROUP BY cl.comment.id")
+    List<Object[]> countByCommentIds(@Param("commentIds") List<UUID> commentIds);
+}

--- a/src/main/java/com/monew/monew_server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/monew/monew_server/domain/comment/repository/CommentRepository.java
@@ -12,7 +12,7 @@ import com.monew.monew_server.domain.article.repository.projection.CommentCountP
 import com.monew.monew_server.domain.comment.entity.Comment;
 
 @Repository
-public interface CommentRepository extends JpaRepository<Comment, UUID> {
+public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
 
 	List<Comment> findByArticle_Id(UUID articleId);
 

--- a/src/main/java/com/monew/monew_server/domain/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/monew/monew_server/domain/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,20 @@
+package com.monew.monew_server.domain.comment.repository;
+
+import com.monew.monew_server.domain.comment.entity.Comment;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+// (인터페이스)
+public interface CommentRepositoryCustom {
+
+    List<Comment> findByArticleIdWithCursor(
+            UUID articleId, // 어떤 기사인지
+            String orderBy, // 정렬 기준
+            String direction, //
+            String cursor,
+            Instant after,
+            int limit
+    );
+}

--- a/src/main/java/com/monew/monew_server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/monew/monew_server/domain/comment/repository/CommentRepositoryImpl.java
@@ -1,0 +1,166 @@
+package com.monew.monew_server.domain.comment.repository;
+
+import com.monew.monew_server.domain.comment.entity.Comment;
+import com.monew.monew_server.domain.comment.entity.QComment;
+import com.monew.monew_server.domain.comment.entity.QCommentLike;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+    // SQL 쿼리를 자바 코드로 조립해줌(JPAQueryFactory)
+    private final JPAQueryFactory queryFactory;
+
+
+    // 메인 메서드 : 커서 기반으로 댓글 조회
+    @Override
+    public List<Comment> findByArticleIdWithCursor(
+            UUID articleId, // 어떤 기사의 댓글?
+            String orderBy, // 정렬 기준 (생성날짜 와 좋아요 수)
+            String direction, // 오름차순 내림차순 결정
+            String cursor, // 마지막으로 본댓글 ID
+            Instant after, // 마지막으로 본 댓글 시간
+            int limit // 몇 개 가져올지
+    ) {
+        QComment comment = QComment.comment;
+
+        // 1. 기본 쿼리 조회시작: WHERE article_id = ?
+        var query = queryFactory
+                .selectFrom(comment) // 특정 컬럼만 선택
+                .where(
+                        comment.article.id.eq(articleId),  // 기사 ID로 필터링
+                        comment.deletedAt.isNull(),         // 삭제되지 않은 댓글만
+                        cursorCondition(comment, orderBy, direction, cursor, after)  // 커서 조건
+                )
+                .orderBy(getOrderSpecifier(comment, orderBy, direction))  // 동적 정렬 (요청 파라미터에 따라 정렬 조건 바꿔주는 것)
+                .limit(limit + 1);  // hasNext 판단을 위해 1개 더 조회
+
+        List<Comment> results = query.fetch();
+
+        log.debug("조회된 댓글 수: {} (limit: {})", results.size(), limit);
+
+        return results;
+    }
+
+
+    // 커서 분별 조건 만들기
+    private BooleanExpression cursorCondition(
+            QComment comment,
+            String orderBy, // 정렬 기준
+            String direction, // 방향 ASD/DESC
+            String cursor, // 마지막으로 본 댓글
+            Instant after // 마지막으로 본 댓글 시간
+    ) {
+        // 첫 페이지는 첫장을 보여주는것 첫장에 아무것도 없다면 null값 반환
+        if (cursor == null || cursor.isEmpty()) {
+            return null;
+        }
+        UUID cursorId = UUID.fromString(cursor); // 문자열을 UUID 로 변환하는 코드
+
+
+        // createdAt 기준으로 커서
+        if ("createdAt".equalsIgnoreCase(orderBy)) { // orderby 체크 좋아요 순인지 생성 순인지.
+            return cursorConditionForCreatedAt(comment, direction, cursorId, after);
+        } else if ("likeCount".equalsIgnoreCase(orderBy)) {
+            return cursorConditionForLikeCount(comment, direction, cursorId);
+        }
+
+        // 기본값: createdAt 기준
+        return cursorConditionForCreatedAt(comment, direction, cursorId, after);
+    }
+
+
+
+    //
+    private BooleanExpression cursorConditionForCreatedAt(
+            QComment comment,
+            String direction,
+            UUID cursorId,
+            Instant after
+    ) {
+        if (after == null) {
+            return null;
+        }
+
+        if ("DESC".equalsIgnoreCase(direction)) {
+            // 내림차순: 더 오래된 댓글
+            return comment.createdAt.lt(after)
+                    .or(comment.createdAt.eq(after).and(comment.id.lt(cursorId)));
+        } else {
+            // 오름차순: 더 최근 댓글
+            return comment.createdAt.gt(after)
+                    .or(comment.createdAt.eq(after).and(comment.id.gt(cursorId)));
+        }
+    }
+
+    /**
+     * likeCount 기준 커서 조건
+     *
+     * <주의>
+     * likeCount는 Comment 엔티티에 직접 저장되지 않고,
+     * CommentLike 테이블을 COUNT 해야 함
+     * 현재는 간단하게 ID 기준으로만 처리
+     * (추후 최적화 필요: likeCount를 Comment 테이블에 비정규화하거나 서브쿼리 사용)
+     */
+    private BooleanExpression cursorConditionForLikeCount(
+            QComment comment,
+            String direction,
+            UUID cursorId
+    ) {
+        if ("DESC".equalsIgnoreCase(direction)) {
+            return comment.id.lt(cursorId);
+        } else {
+            return comment.id.gt(cursorId);
+        }
+    }
+
+    /**
+     * 동적 정렬 조건 생성
+     *
+     * <OrderSpecifier란?>
+     * QueryDSL에서 ORDER BY 절을 표현하는 객체
+     * - Order.ASC / Order.DESC: 정렬 방향
+     * - comment.createdAt: 정렬할 컬럼
+     *
+     * @param comment   QComment 엔티티
+     * @param orderBy   정렬 기준
+     * @param direction 정렬 방향
+     * @return OrderSpecifier 배열
+     */
+    private OrderSpecifier<?>[] getOrderSpecifier(QComment comment, String orderBy, String direction) {
+        Order order = "DESC".equalsIgnoreCase(direction) ? Order.DESC : Order.ASC;
+        OrderSpecifier<?> idOrder = new OrderSpecifier<>(order, comment.id);
+
+        if ("likeCount".equalsIgnoreCase(orderBy)) {
+            QCommentLike subCommentLike = new QCommentLike("subCommentLike");
+
+            OrderSpecifier<?> likeCountOrder = new OrderSpecifier<>(
+                    order,
+                    JPAExpressions
+                            .select(subCommentLike.count())
+                            .from(subCommentLike)
+                            .where(subCommentLike.comment.eq(comment))
+            );
+
+            return new OrderSpecifier[]{likeCountOrder, idOrder};
+        }
+
+        return new OrderSpecifier[]{
+                new OrderSpecifier<>(order, comment.createdAt),
+                idOrder
+        };
+    }
+}

--- a/src/main/java/com/monew/monew_server/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/monew/monew_server/domain/comment/service/CommentLikeService.java
@@ -1,0 +1,88 @@
+package com.monew.monew_server.domain.comment.service;
+
+import com.monew.monew_server.domain.comment.dto.CommentLikeDto;
+import com.monew.monew_server.domain.comment.entity.Comment;
+import com.monew.monew_server.domain.comment.entity.CommentLike;
+import com.monew.monew_server.domain.comment.repository.CommentLikeRepository;
+import com.monew.monew_server.domain.comment.repository.CommentRepository;
+import com.monew.monew_server.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentLikeService {
+
+    private final CommentLikeRepository commentLikeRepository;
+    private final CommentRepository commentRepository;
+    private final EntityManager entityManager;
+
+    @Transactional
+    public CommentLikeDto addLike(UUID commentId, UUID userId) {
+        log.info("좋아요 추가 요청: commentId={}, userId={}", commentId, userId);
+
+        // 1. 댓글이 존재하는지 확인
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
+
+        // 2. 삭제된 댓글인지 체크
+        if (comment.isDeleted()) {
+            throw new IllegalStateException("삭제된 댓글에는 좋아요를 누를 수 없습니다.");
+        }
+
+        // 3. 이미 좋아요를 눌렀는지 체크 (중복 방지)
+        if (commentLikeRepository.findByComment_IdAndUser_Id(commentId, userId).isPresent()) {
+            throw new IllegalStateException("이미 좋아요를 누른 댓글입니다.");
+        }
+
+        // 4. User 객체 가져오기 (userId만 있으면 되니까 getReference 사용)
+        User user = entityManager.getReference(User.class, userId);
+
+        // 5. CommentLike 엔티티 생성
+        CommentLike commentLike = CommentLike.builder()
+                .comment(comment)
+                .user(user)
+                .build();
+
+        // 6. DB에 저장
+        CommentLike savedLike = commentLikeRepository.save(commentLike);
+        log.info("좋아요 추가 완료: likeId={}", savedLike.getId());
+
+        // 7. 현재 좋아요 개수 조회
+        long likeCount = commentLikeRepository.countByComment_Id(commentId);
+
+        // 8. 응답 DTO 생성 (Swagger 명세에 맞춰 댓글 정보도 함께 반환)
+        return CommentLikeDto.builder()
+                .id(savedLike.getId())
+                .likedBy(userId)
+                .createdAt(savedLike.getCreatedAt())
+                .commentId(comment.getId())
+                .articleId(comment.getArticle().getId())
+                .commentUserId(comment.getUser().getId())
+                .commentUserNickname(comment.getUser().getNickname())
+                .commentContent(comment.getContent())
+                .commentLikeCount(likeCount)
+                .commentCreatedAt(comment.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public void removeLike(UUID commentId, UUID userId) {
+        log.info("좋아요 취소 요청: commentId={}, userId={}", commentId, userId);
+
+        // 1. 좋아요 찾기 (댓글ID + 유저ID로 조회)
+        CommentLike commentLike = commentLikeRepository.findByComment_IdAndUser_Id(commentId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("좋아요를 찾을 수 없습니다."));
+
+        // 2. DB에서 삭제
+        commentLikeRepository.delete(commentLike);
+        log.info("좋아요 취소 완료: commentId={}, userId={}", commentId, userId);
+    }
+}


### PR DESCRIPTION
## PR 요약
댓글 목록 조회 기능(커서 페이지네이션)과 좋아요 추가/취소 기능을
구현했습니다.


## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#xxx)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
1. **댓글 목록 조회 API** (`GET /api/comments`)
    - 커서 기반 페이지네이션 구현
    - 정렬 옵션: 생성일시(createdAt), 좋아요 순(likeCount)
    - likedByMe, likeCount 필드 제공

2. **좋아요 추가 API** (`POST /api/comments/{commentId}/comment-likes`)
    - 중복 좋아요 방지
    - 삭제된 댓글 좋아요 차단

3. **좋아요 취소 API** (`DELETE /api/comments/{commentId}/comment-likes`)

### 기술 구현
- QueryDSL을 사용한 동적 쿼리 구현 (CommentRepositoryImpl)
- IN 절 Bulk Query로 N+1 문제 해결
- 서브쿼리를 사용한 likeCount 정렬


## 검증 단계
1. CommentControllerTest 7개 테스트 모두 통과 확인
    - 댓글 생성 테스트
    - 댓글 수정 테스트
    - 댓글 목록 조회 테스트 (커서 페이지네이션)
    - 논리 삭제 테스트
    - 물리 삭제 테스트
    - 좋아요 추가 테스트
    - 좋아요 취소 테스트
2. Swagger API 명세 준수 확인



## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->
