### PR TITLE
Dev/test/mongodb#83

### DIFF
--- a/src/main/java/com/monew/monew_server/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/monew/monew_server/domain/article/controller/ArticleController.java
@@ -30,9 +30,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/articles")
 public class ArticleController {
 
-	private final ArticleService articleService;
-
 	private static final String USER_ID_HEADER = "Monew-Request-User-ID";
+	private final ArticleService articleService;
 
 	private UUID getUserIdFromHeader(String userIdHeader) {
 		if (userIdHeader == null || userIdHeader.isBlank()) {
@@ -81,6 +80,18 @@ public class ArticleController {
 
 	@GetMapping("/{articleId}")
 	public ResponseEntity<ArticleResponse> getArticleById(
+		@PathVariable UUID articleId,
+		@RequestHeader(value = USER_ID_HEADER, required = false) String userIdHeader
+	) {
+		UUID userId = getUserIdFromHeader(userIdHeader);
+		log.info("GET /api/articles/{} - (사용자 ID: {})", articleId, userId);
+
+		ArticleResponse response = articleService.getArticleById(articleId, userId);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/{articleId}/mongo")
+	public ResponseEntity<ArticleResponse> getArticleByIdMongo(
 		@PathVariable UUID articleId,
 		@RequestHeader(value = USER_ID_HEADER, required = false) String userIdHeader
 	) {

--- a/src/main/java/com/monew/monew_server/domain/article/entity/Article.java
+++ b/src/main/java/com/monew/monew_server/domain/article/entity/Article.java
@@ -1,16 +1,19 @@
 package com.monew.monew_server.domain.article.entity;
 
+import java.time.Instant;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.monew.monew_server.domain.article.dto.ArticleSaveDto;
 import com.monew.monew_server.domain.common.BaseDeletableEntity;
 import com.monew.monew_server.domain.interest.entity.ArticleInterest;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.Instant;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -37,6 +40,7 @@ public class Article extends BaseDeletableEntity {
 
 	private String title;
 
+	@Column(name = "summary", columnDefinition = "TEXT")
 	private String summary;
 
 	private Instant publishDate;

--- a/src/main/java/com/monew/monew_server/domain/article/service/ArticleService.java
+++ b/src/main/java/com/monew/monew_server/domain/article/service/ArticleService.java
@@ -1,5 +1,19 @@
 package com.monew.monew_server.domain.article.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
 import com.monew.monew_server.domain.article.dto.ArticleRequest;
 import com.monew.monew_server.domain.article.dto.ArticleResponse;
 import com.monew.monew_server.domain.article.dto.ArticleRestoreResult;
@@ -24,27 +38,20 @@ import com.monew.monew_server.domain.interest.entity.InterestKeyword;
 import com.monew.monew_server.domain.interest.repository.InterestKeywordRepository;
 import com.monew.monew_server.domain.interest.repository.InterestRepository;
 import com.monew.monew_server.domain.user.entity.User;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.MUserActivityService;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
 import com.monew.monew_server.exception.ArticleException;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 public class ArticleService {
 
+	private static final int DEFAULT_PAGE_SIZE = 10;
 	private final ArticleRepository articleRepository;
 	private final ArticleRepositoryCustom articleRepositoryCustom;
 	private final ArticleMapper articleMapper;
@@ -54,6 +61,10 @@ public class ArticleService {
 	private final InterestRepository interestRepository;
 	private final ArticleInterestRepository articleInterestRepository;
 	private final InterestKeywordRepository interestKeywordRepository;
+	@Autowired
+	private MUserActivityService mUserActivityService;
+	@PersistenceContext
+	private EntityManager entityManager;
 
 	public ArticleService(
 		ArticleRepository articleRepository,
@@ -75,10 +86,6 @@ public class ArticleService {
 		this.interestKeywordRepository = interestKeywordRepository;
 	}
 
-	private static final int DEFAULT_PAGE_SIZE = 10;
-	@PersistenceContext
-	private EntityManager entityManager;
-
 	public CursorPageResponseArticleDto fetchArticles(ArticleRequest request, UUID currentUserId) {
 
 		int requestedSize = request.limit() != null ? request.limit() : DEFAULT_PAGE_SIZE;
@@ -98,7 +105,7 @@ public class ArticleService {
 
 		var commentCounts = commentRepository.findCommentCountsByArticleIds(articleIds)
 			.stream().collect(Collectors.toMap(CommentCountProjection::getArticleId,
-                CommentCountProjection::getCommentCount));
+				CommentCountProjection::getCommentCount));
 
 		List<ArticleResponse> enrichedResponses = allResponses.stream().map(resp ->
 			new ArticleResponse(
@@ -183,14 +190,40 @@ public class ArticleService {
 		Article article = articleRepositoryCustom.findArticleById(articleId)
 			.orElseThrow(ArticleException::new);
 
-		if (userId != null && !articleViewRepository.existsByArticleIdAndUserId(articleId, userId)) {
-			User userRef = entityManager.getReference(User.class, userId);
-			articleViewRepository.save(ArticleView.of(article, userRef));
+		boolean viewedByMe = false;
+
+		if (userId != null) {
+			viewedByMe = articleViewRepository.existsByArticleIdAndUserId(articleId, userId);
+
+			if (!viewedByMe) {
+				ArticleView saved = saveArticleViewToRdb(article, userId);
+			}
 		}
 
 		long viewCount = articleViewRepository.countByArticleId(articleId);
 		long commentCount = commentRepository.countByArticleId(articleId);
-		boolean viewedByMe = userId != null && articleViewRepository.existsByArticleIdAndUserId(articleId, userId);
+
+		return articleMapper.toResponse(article, viewCount, commentCount, viewedByMe);
+	}
+
+	@Transactional
+	public ArticleResponse getArticleByIdMongo(UUID articleId, UUID userId) {
+		Article article = articleRepositoryCustom.findArticleById(articleId)
+			.orElseThrow(ArticleException::new);
+
+		boolean viewedByMe = false;
+
+		if (userId != null) {
+			viewedByMe = articleViewRepository.existsByArticleIdAndUserId(articleId, userId);
+
+			if (!viewedByMe) {
+				ArticleView saved = saveArticleViewToRdb(article, userId);
+				addMongoArticleView(userId, saved);
+			}
+		}
+
+		long viewCount = articleViewRepository.countByArticleId(articleId);
+		long commentCount = commentRepository.countByArticleId(articleId);
 
 		return articleMapper.toResponse(article, viewCount, commentCount, viewedByMe);
 	}
@@ -210,7 +243,8 @@ public class ArticleService {
 
 		if (userId != null && !articleViewRepository.existsByArticleIdAndUserId(articleId, userId)) {
 			User userRef = entityManager.getReference(User.class, userId);
-			articleViewRepository.save(ArticleView.of(article, userRef));
+			ArticleView save = articleViewRepository.save(ArticleView.of(article, userRef));
+			addMongoArticleView(userId, save);
 		}
 	}
 
@@ -350,5 +384,28 @@ public class ArticleService {
 			current = current.plusDays(1);
 		}
 		return results;
+	}
+
+	// mongo
+	public void addMongoArticleView(UUID userId, ArticleView articleView) {
+		MUserActivity.ArticleView build = MUserActivity.ArticleView.builder()
+			.id(articleView.getId())
+			.viewedBy(userId)
+			.createdAt(articleView.getCreatedAt())
+			.articleId(articleView.getArticle().getId())
+			.source(articleView.getArticle().getSource().name())
+			.sourceUrl(articleView.getArticle().getSourceUrl())
+			.articleTitle(articleView.getArticle().getTitle())
+			.articlePublishedDate(articleView.getArticle().getPublishDate())
+			.articleSummary(articleView.getArticle().getSummary())
+			.articleCommentCount((int)commentRepository.countByArticleId(articleView.getArticle().getId()))
+			.articleViewCount((int)articleViewRepository.countByArticleId(articleView.getArticle().getId())).build();
+
+		mUserActivityService.addArticleView(userId, build);
+	}
+
+	private ArticleView saveArticleViewToRdb(Article article, UUID userId) {
+		User userRef = entityManager.getReference(User.class, userId);
+		return articleViewRepository.save(ArticleView.of(article, userRef));
 	}
 }

--- a/src/main/java/com/monew/monew_server/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/monew/monew_server/domain/comment/service/CommentLikeService.java
@@ -1,5 +1,10 @@
 package com.monew.monew_server.domain.comment.service;
 
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.monew.monew_server.domain.comment.dto.CommentLikeDto;
 import com.monew.monew_server.domain.comment.entity.Comment;
 import com.monew.monew_server.domain.comment.entity.CommentLike;
@@ -8,91 +13,124 @@ import com.monew.monew_server.domain.comment.repository.CommentRepository;
 import com.monew.monew_server.domain.notification.service.NotificationService;
 import com.monew.monew_server.domain.user.entity.User;
 import com.monew.monew_server.domain.user.repository.UserRepository;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.MUserActivityService;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CommentLikeService {
 
-    private final CommentLikeRepository commentLikeRepository;
-    private final CommentRepository commentRepository;
-    private final EntityManager entityManager;
-    private final NotificationService notificationService;
+	private final CommentLikeRepository commentLikeRepository;
+	private final CommentRepository commentRepository;
+	private final NotificationService notificationService;
 	private final UserRepository userRepository;
+	private final MUserActivityService mUserActivityService;
 
-    @Transactional
-    public CommentLikeDto addLike(UUID commentId, UUID userId) {
-        log.info("좋아요 추가 요청: commentId={}, userId={}", commentId, userId);
+	@Transactional
+	public CommentLikeDto addLike(UUID commentId, UUID userId) {
+		log.info("좋아요 추가 요청: commentId={}, userId={}", commentId, userId);
 
-        // 1. 댓글이 존재하는지 확인
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
+		// 1. 댓글이 존재하는지 확인
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
 
-        // 2. 삭제된 댓글인지 체크
-        if (comment.isDeleted()) {
-            throw new IllegalStateException("삭제된 댓글에는 좋아요를 누를 수 없습니다.");
-        }
+		// 2. 삭제된 댓글인지 체크
+		if (comment.isDeleted()) {
+			throw new IllegalStateException("삭제된 댓글에는 좋아요를 누를 수 없습니다.");
+		}
 
-        // 3. 이미 좋아요를 눌렀는지 체크 (중복 방지)
-        if (commentLikeRepository.findByComment_IdAndUser_Id(commentId, userId).isPresent()) {
-            throw new IllegalStateException("이미 좋아요를 누른 댓글입니다.");
-        }
+		// 3. 이미 좋아요를 눌렀는지 체크 (중복 방지)
+		if (commentLikeRepository.findByComment_IdAndUser_Id(commentId, userId).isPresent()) {
+			throw new IllegalStateException("이미 좋아요를 누른 댓글입니다.");
+		}
 
-        // 4. User 객체 가져오기 (userId만 있으면 되니까 getReference 사용)
+		// 4. User 객체 가져오기 (userId만 있으면 되니까 getReference 사용)
 		User user = userRepository.findById(userId).orElseThrow();
 
 		// 5. CommentLike 엔티티 생성
-        CommentLike commentLike = CommentLike.builder()
-                .comment(comment)
-                .user(user)
-                .build();
+		CommentLike commentLike = CommentLike.builder()
+			.comment(comment)
+			.user(user)
+			.build();
 
-        // 6. DB에 저장
-        CommentLike savedLike = commentLikeRepository.save(commentLike);
-        log.info("좋아요 추가 완료: likeId={}", savedLike.getId());
+		// 6. DB에 저장
+		CommentLike savedLike = commentLikeRepository.save(commentLike);
+		log.info("좋아요 추가 완료: likeId={}", savedLike.getId());
+		saveMongoCommentLike(userId, savedLike);
 
-        // 7. 알림 생성 (댓글 작성자에게 알림 전송, 본인 체크는 NotificationService에서 처리)
-        notificationService.createCommentLikeNotification(comment, userId);
-        log.info("알림 생성 요청 완료: commentId={}, likedBy={}", comment.getId(), userId);
+		// 7. 알림 생성 (댓글 작성자에게 알림 전송, 본인 체크는 NotificationService에서 처리)
+		notificationService.createCommentLikeNotification(comment, userId);
+		log.info("알림 생성 요청 완료: commentId={}, likedBy={}", comment.getId(), userId);
 
-        // 8. 현재 좋아요 개수 조회
-        long likeCount = commentLikeRepository.countByComment_Id(commentId);
+		// 8. 현재 좋아요 개수 조회
+		long likeCount = commentLikeRepository.countByComment_Id(commentId);
 
-        // 9. 응답 DTO 생성 (Swagger 명세에 맞춰 댓글 정보도 함께 반환)
-        return CommentLikeDto.builder()
-                .id(savedLike.getId())
-                .likedBy(userId)
-                .createdAt(savedLike.getCreatedAt())
-                .commentId(comment.getId())
-                .articleId(comment.getArticle().getId())
-                .commentUserId(comment.getUser().getId())
-                .commentUserNickname(comment.getUser().getNickname())
-                .commentContent(comment.getContent())
-                .commentLikeCount(likeCount)
-                .commentCreatedAt(comment.getCreatedAt())
-                .build();
-    }
+		// 9. 응답 DTO 생성 (Swagger 명세에 맞춰 댓글 정보도 함께 반환)
+		return CommentLikeDto.builder()
+			.id(savedLike.getId())
+			.likedBy(userId)
+			.createdAt(savedLike.getCreatedAt())
+			.commentId(comment.getId())
+			.articleId(comment.getArticle().getId())
+			.commentUserId(comment.getUser().getId())
+			.commentUserNickname(comment.getUser().getNickname())
+			.commentContent(comment.getContent())
+			.commentLikeCount(likeCount)
+			.commentCreatedAt(comment.getCreatedAt())
+			.build();
+	}
 
-    @Transactional
-    public void removeLike(UUID commentId, UUID userId) {
-        log.info("좋아요 취소 요청: commentId={}, userId={}", commentId, userId);
+	@Transactional
+	public void removeLike(UUID commentId, UUID userId) {
+		log.info("좋아요 취소 요청: commentId={}, userId={}", commentId, userId);
 
-        // 1. 좋아요 찾기 (댓글ID + 유저ID로 조회)
-        CommentLike commentLike = commentLikeRepository.findByComment_IdAndUser_Id(commentId, userId)
-                .orElseThrow(() -> new EntityNotFoundException("좋아요를 찾을 수 없습니다."));
+		// 1. 좋아요 찾기 (댓글ID + 유저ID로 조회)
+		CommentLike commentLike = commentLikeRepository.findByComment_IdAndUser_Id(commentId, userId)
+			.orElseThrow(() -> new EntityNotFoundException("좋아요를 찾을 수 없습니다."));
 
-        // 2. DB에서 삭제
-        commentLikeRepository.delete(commentLike);
-        log.info("좋아요 취소 완료: commentId={}, userId={}", commentId, userId);
-    }
+		// 2. DB에서 삭제
+		commentLikeRepository.delete(commentLike);
+		log.info("좋아요 취소 완료: commentId={}, userId={}", commentId, userId);
+	}
+
+	/**
+	 * @Data
+	 *        @Builder
+	 *    public static class CommentLike {
+	 * 		private UUID id;
+	 * 		private Instant createdAt;
+	 * 		private UUID commentId;
+	 * 		private UUID articleId;
+	 * 		private String articleTitle;
+	 * 		private UUID commentUserId;
+	 * 		private String commentUserNickname;
+	 * 		private String commentContent;
+	 * 		private Integer commentLikeCount;
+	 * 		private Instant commentCreatedAt;
+	 */
+
+	public void saveMongoCommentLike(UUID userId, CommentLike commentLike) {
+
+		int count = (int)commentLikeRepository.countByComment_Id(commentLike.getComment().getId());
+
+		MUserActivity.CommentLike build = MUserActivity.CommentLike.builder()
+			.id(commentLike.getId())
+			.createdAt(commentLike.getCreatedAt())
+			.commentId(commentLike.getComment().getId())
+			.articleId(commentLike.getComment().getArticle().getId())
+			.articleTitle(commentLike.getComment().getArticle().getTitle())
+			.commentUserId(commentLike.getComment().getUser().getId())
+			.commentUserNickname(commentLike.getComment().getUser().getNickname())
+			.commentContent(commentLike.getComment().getContent())
+			.commentLikeCount(count)
+			.commentCreatedAt(commentLike.getComment().getCreatedAt())
+			.build();
+
+		mUserActivityService.addCommentLike(userId, build);
+	}
 }

--- a/src/main/java/com/monew/monew_server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/monew/monew_server/domain/comment/service/CommentService.java
@@ -1,4 +1,16 @@
 package com.monew.monew_server.domain.comment.service;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.monew.monew_server.domain.article.entity.Article;
 import com.monew.monew_server.domain.comment.dto.CommentDto;
 import com.monew.monew_server.domain.comment.dto.CommentRegisterRequest;
@@ -8,233 +20,255 @@ import com.monew.monew_server.domain.comment.entity.Comment;
 import com.monew.monew_server.domain.comment.repository.CommentLikeRepository;
 import com.monew.monew_server.domain.comment.repository.CommentRepository;
 import com.monew.monew_server.domain.user.entity.User;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.MUserActivityService;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 
-    private final CommentRepository commentRepository;
-    private final CommentLikeRepository commentLikeRepository;
-    private final EntityManager entityManager;
+	private final CommentRepository commentRepository;
+	private final CommentLikeRepository commentLikeRepository;
+	private final EntityManager entityManager;
+	private final MUserActivityService mUserActivityService;
 
-    @Transactional
-    public CommentDto createComment(CommentRegisterRequest request) {
-        log.info("댓글 생성 요청: articleId={}, userId={}",
-                request.getArticleId(), request.getUserId());
+	@Transactional
+	public CommentDto createComment(CommentRegisterRequest request) {
+		log.info("댓글 생성 요청: articleId={}, userId={}",
+			request.getArticleId(), request.getUserId());
 
-        Article article = entityManager.getReference(Article.class, request.getArticleId());
-        User user = entityManager.getReference(User.class, request.getUserId());
+		Article article = entityManager.getReference(Article.class, request.getArticleId());
+		User user = entityManager.getReference(User.class, request.getUserId());
 
-        Comment comment = Comment.builder()
-                .article(article)
-                .user(user)
-                .content(request.getContent())
-                .build();
+		Comment comment = Comment.builder()
+			.article(article)
+			.user(user)
+			.content(request.getContent())
+			.build();
 
-        Comment savedComment = commentRepository.save(comment);
-        log.info("댓글 생성 완료: commentId={}", savedComment.getId());
+		Comment savedComment = commentRepository.save(comment);
 
-        return convertToDto(savedComment);
-    }
+		log.info("댓글 생성 완료: commentId={}", savedComment.getId());
 
-    private CommentDto convertToDto(Comment comment) {
-        return CommentDto.builder()
-                .id(comment.getId())
-                .articleId(comment.getArticle() != null ? comment.getArticle().getId() : null)
-                .userId(comment.getUser() != null ? comment.getUser().getId() : null)
-                .userNickname(comment.getUser() != null ? comment.getUser().getNickname() : "임시닉네임")
-                .content(comment.getContent())
-                .likeCount(0L)
-                .likedByMe(false)
-                .createdAt(comment.getCreatedAt())
-                .build();
-    }
+		saveMongoComment(user.getId(), savedComment);
 
-    @Transactional(readOnly = true)
-    public CursorPageResponse<CommentDto> getComments(
-        UUID articleId,
-        String orderBy,
-        String direction,
-        String cursor,
-        Instant after,
-        int limit,
-        UUID userId
-    ) {
-        log.info("댓글 조회 요청: articleId={}, orderBy={}, direction={}, cursor={}, limit={}, userId={}",
-            articleId, orderBy, direction, cursor, limit, userId);
+		return convertToDto(savedComment);
+	}
 
-        List<Comment> comments = commentRepository.findByArticleIdWithCursor(
-            articleId, orderBy, direction, cursor, after, limit
-        );
+	private CommentDto convertToDto(Comment comment) {
+		return CommentDto.builder()
+			.id(comment.getId())
+			.articleId(comment.getArticle() != null ? comment.getArticle().getId() : null)
+			.userId(comment.getUser() != null ? comment.getUser().getId() : null)
+			.userNickname(comment.getUser() != null ? comment.getUser().getNickname() : "임시닉네임")
+			.content(comment.getContent())
+			.likeCount(0L)
+			.likedByMe(false)
+			.createdAt(comment.getCreatedAt())
+			.build();
+	}
 
-        log.info("조회된 댓글 수: {} (limit: {})", comments.size(), limit);
+	@Transactional(readOnly = true)
+	public CursorPageResponse<CommentDto> getComments(
+		UUID articleId,
+		String orderBy,
+		String direction,
+		String cursor,
+		Instant after,
+		int limit,
+		UUID userId
+	) {
+		log.info("댓글 조회 요청: articleId={}, orderBy={}, direction={}, cursor={}, limit={}, userId={}",
+			articleId, orderBy, direction, cursor, limit, userId);
 
-        boolean hasNext = comments.size() > limit;
-        List<Comment> actualComments = hasNext ? comments.subList(0, limit) : comments;
+		List<Comment> comments = commentRepository.findByArticleIdWithCursor(
+			articleId, orderBy, direction, cursor, after, limit
+		);
 
-        List<UUID> commentIds = actualComments.stream()
-            .map(Comment::getId)
-            .collect(Collectors.toList());
+		log.info("조회된 댓글 수: {} (limit: {})", comments.size(), limit);
 
-        Set<UUID> likedCommentIds = getLikedCommentIds(commentIds, userId);
-        Map<UUID, Long> likeCountMap = getLikeCountMap(commentIds);
+		boolean hasNext = comments.size() > limit;
+		List<Comment> actualComments = hasNext ? comments.subList(0, limit) : comments;
 
-        List<CommentDto> commentDtos = actualComments.stream()
-            .map(comment -> convertToDtoWithLikes(comment, likedCommentIds, likeCountMap))
-            .collect(Collectors.toList());
+		List<UUID> commentIds = actualComments.stream()
+			.map(Comment::getId)
+			.collect(Collectors.toList());
 
-        String nextCursor = null;
-        Instant nextAfter = null;
-        if (hasNext && !actualComments.isEmpty()) {
-            Comment lastComment = actualComments.get(actualComments.size() - 1);
-            nextCursor = lastComment.getId().toString();
-            nextAfter = lastComment.getCreatedAt();
-        }
+		Set<UUID> likedCommentIds = getLikedCommentIds(commentIds, userId);
+		Map<UUID, Long> likeCountMap = getLikeCountMap(commentIds);
 
-        long totalElements = commentRepository.countByArticleId(articleId);
+		List<CommentDto> commentDtos = actualComments.stream()
+			.map(comment -> convertToDtoWithLikes(comment, likedCommentIds, likeCountMap))
+			.collect(Collectors.toList());
 
-        return CursorPageResponse.<CommentDto>builder()
-            .content(commentDtos)
-            .nextCursor(nextCursor)
-            .nextAfter(nextAfter)
-            .size(commentDtos.size())
-            .totalElements(totalElements)
-            .hasNext(hasNext)
-            .build();
-    }
+		String nextCursor = null;
+		Instant nextAfter = null;
+		if (hasNext && !actualComments.isEmpty()) {
+			Comment lastComment = actualComments.get(actualComments.size() - 1);
+			nextCursor = lastComment.getId().toString();
+			nextAfter = lastComment.getCreatedAt();
+		}
 
-    private Set<UUID> getLikedCommentIds(List<UUID> commentIds, UUID userId) {
-        if (commentIds.isEmpty() || userId == null) {
-            return Set.of();
-        }
+		long totalElements = commentRepository.countByArticleId(articleId);
 
-        return commentLikeRepository.findByCommentIdsAndUserId(commentIds, userId)
-            .stream()
-            .map(commentLike -> commentLike.getComment().getId())
-            .collect(Collectors.toSet());
-    }
+		return CursorPageResponse.<CommentDto>builder()
+			.content(commentDtos)
+			.nextCursor(nextCursor)
+			.nextAfter(nextAfter)
+			.size(commentDtos.size())
+			.totalElements(totalElements)
+			.hasNext(hasNext)
+			.build();
+	}
 
-    private Map<UUID, Long> getLikeCountMap(List<UUID> commentIds) {
-        if (commentIds.isEmpty()) {
-            return Map.of();
-        }
+	private Set<UUID> getLikedCommentIds(List<UUID> commentIds, UUID userId) {
+		if (commentIds.isEmpty() || userId == null) {
+			return Set.of();
+		}
 
-        List<Object[]> results = commentLikeRepository.countByCommentIds(commentIds);
+		return commentLikeRepository.findByCommentIdsAndUserId(commentIds, userId)
+			.stream()
+			.map(commentLike -> commentLike.getComment().getId())
+			.collect(Collectors.toSet());
+	}
 
-        Map<UUID, Long> likeCountMap = new HashMap<>();
-        for (Object[] result : results) {
-            UUID commentId = (UUID) result[0];
-            Long count = (Long) result[1];
-            likeCountMap.put(commentId, count);
-        }
+	private Map<UUID, Long> getLikeCountMap(List<UUID> commentIds) {
+		if (commentIds.isEmpty()) {
+			return Map.of();
+		}
 
-        return likeCountMap;
-    }
+		List<Object[]> results = commentLikeRepository.countByCommentIds(commentIds);
 
-    private CommentDto convertToDtoWithLikes(
-        Comment comment,
-        Set<UUID> likedCommentIds,
-        Map<UUID, Long> likeCountMap
-    ) {
-        return CommentDto.builder()
-            .id(comment.getId())
-            .articleId(comment.getArticle() != null ? comment.getArticle().getId() : null)
-            .userId(comment.getUser() != null ? comment.getUser().getId() : null)
-            .userNickname(comment.getUser() != null ? comment.getUser().getNickname() : "탈퇴한 사용자")
-            .content(comment.getContent())
-            .likeCount(likeCountMap.getOrDefault(comment.getId(), 0L))
-            .likedByMe(likedCommentIds.contains(comment.getId()))
-            .createdAt(comment.getCreatedAt())
-            .build();
-    }
+		Map<UUID, Long> likeCountMap = new HashMap<>();
+		for (Object[] result : results) {
+			UUID commentId = (UUID)result[0];
+			Long count = (Long)result[1];
+			likeCountMap.put(commentId, count);
+		}
 
+		return likeCountMap;
+	}
 
-    @Transactional
-    public CommentDto updateComment(UUID commentId, UUID userId, CommentUpdateRequest request) {
-        log.info("댓글 수정 요청: commentId={}, userId={}", commentId, userId);
+	private CommentDto convertToDtoWithLikes(
+		Comment comment,
+		Set<UUID> likedCommentIds,
+		Map<UUID, Long> likeCountMap
+	) {
+		return CommentDto.builder()
+			.id(comment.getId())
+			.articleId(comment.getArticle() != null ? comment.getArticle().getId() : null)
+			.userId(comment.getUser() != null ? comment.getUser().getId() : null)
+			.userNickname(comment.getUser() != null ? comment.getUser().getNickname() : "탈퇴한 사용자")
+			.content(comment.getContent())
+			.likeCount(likeCountMap.getOrDefault(comment.getId(), 0L))
+			.likedByMe(likedCommentIds.contains(comment.getId()))
+			.createdAt(comment.getCreatedAt())
+			.build();
+	}
 
-        // 1. 댓글 조회
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
+	@Transactional
+	public CommentDto updateComment(UUID commentId, UUID userId, CommentUpdateRequest request) {
+		log.info("댓글 수정 요청: commentId={}, userId={}", commentId, userId);
 
-        // 2. 삭제된 댓글 체크
-        if (comment.isDeleted()) {
-            log.warn("삭제된 댓글 수정 시도: commentId={}", commentId);
-            throw new IllegalStateException("삭제된 댓글은 수정할 수 없습니다.");
-        }
+		// 1. 댓글 조회
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
 
-        // 3. 본인 확인 (작성자만 수정 가능)
-        if (!comment.getUser().getId().equals(userId)) {
-            log.warn("권한 없음: 댓글 작성자({})와 요청자({})가 다름", comment.getUser().getId(), userId);
-            throw new IllegalArgumentException("본인이 작성한 댓글만 수정할 수 있습니다.");
-        }
+		// 2. 삭제된 댓글 체크
+		if (comment.isDeleted()) {
+			log.warn("삭제된 댓글 수정 시도: commentId={}", commentId);
+			throw new IllegalStateException("삭제된 댓글은 수정할 수 없습니다.");
+		}
 
-        // 4. 내용 수정
-        comment.setContent(request.getContent());
-        // JPA의 더티 체킹: @Transactional 내에서 엔티티 변경 시 자동으로 UPDATE 쿼리 실행
-        // save() 호출 불필요! (하지만 명시적으로 save()를 호출해도 문제 없다고함)
+		// 3. 본인 확인 (작성자만 수정 가능)
+		if (!comment.getUser().getId().equals(userId)) {
+			log.warn("권한 없음: 댓글 작성자({})와 요청자({})가 다름", comment.getUser().getId(), userId);
+			throw new IllegalArgumentException("본인이 작성한 댓글만 수정할 수 있습니다.");
+		}
 
-        log.info("댓글 수정 완료: commentId={}", commentId);
+		// 4. 내용 수정
+		comment.setContent(request.getContent());
+		// JPA의 더티 체킹: @Transactional 내에서 엔티티 변경 시 자동으로 UPDATE 쿼리 실행
+		// save() 호출 불필요! (하지만 명시적으로 save()를 호출해도 문제 없다고함)
 
-        // 5. DTO 변환 후 반환
-        return convertToDto(comment);
-    }
+		log.info("댓글 수정 완료: commentId={}", commentId);
 
+		// 5. DTO 변환 후 반환
+		return convertToDto(comment);
+	}
 
-    @Transactional
-    public void deleteComment(UUID commentId, UUID userId) {
-        log.info("댓글 논리 삭제 요청: commentId={}, userId={}", commentId, userId);
+	@Transactional
+	public void deleteComment(UUID commentId, UUID userId) {
+		log.info("댓글 논리 삭제 요청: commentId={}, userId={}", commentId, userId);
 
-        // 1. 댓글 조회
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
-        // 2. 사용자 본인인지 확인
-        if (!comment.getUser().getId().equals(userId)) {
-            log.warn("권한 없음: 댓글 작성자({})와 요청자({})가 다름", comment.getUser().getId(), userId);
-            throw new IllegalArgumentException("본인이 작성한 댓글만 삭제할 수 있습니다.");
-        }
+		// 1. 댓글 조회
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
+		// 2. 사용자 본인인지 확인
+		if (!comment.getUser().getId().equals(userId)) {
+			log.warn("권한 없음: 댓글 작성자({})와 요청자({})가 다름", comment.getUser().getId(), userId);
+			throw new IllegalArgumentException("본인이 작성한 댓글만 삭제할 수 있습니다.");
+		}
 
-        // 3. 이미 삭제된 댓글인지 체크
-        if (comment.isDeleted()) {
-            log.warn("이미 삭제된 댓글: commentId={}", commentId);
-            throw new IllegalStateException("이미 삭제된 댓글입니다.");
-        }
+		// 3. 이미 삭제된 댓글인지 체크
+		if (comment.isDeleted()) {
+			log.warn("이미 삭제된 댓글: commentId={}", commentId);
+			throw new IllegalStateException("이미 삭제된 댓글입니다.");
+		}
 
-        // 4. 논리 삭제 실행
-        comment.softDelete();
+		// 4. 논리 삭제 실행
+		comment.softDelete();
 
-        // JPA 더티 체킹으로 자동 UPDATE (deleted_at = now())
-        log.info("댓글 논리 삭제 완료: commentId={}", commentId);
-    }
+		// JPA 더티 체킹으로 자동 UPDATE (deleted_at = now())
+		log.info("댓글 논리 삭제 완료: commentId={}", commentId);
+	}
 
+	@Transactional
+	public void hardDeleteComment(UUID commentId) {
+		log.info("댓글 물리 삭제 요청: commentId={}", commentId);
 
-    @Transactional
-    public void hardDeleteComment(UUID commentId) {
-        log.info("댓글 물리 삭제 요청: commentId={}", commentId);
+		// 1. 댓글 조회 (존재 여부 확인)
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
 
-        // 1. 댓글 조회 (존재 여부 확인)
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
+		// 2. 물리 삭제 실행 (DB에서 완전히 제거)
+		commentRepository.delete(comment);
 
-        // 2. 물리 삭제 실행 (DB에서 완전히 제거)
-        commentRepository.delete(comment);
+		log.info("댓글 물리 삭제 완료: commentId={}", commentId);
+	}
 
-        log.info("댓글 물리 삭제 완료: commentId={}", commentId);
-    }
+	// mongoDB용
 
+	/**
+	 * 		private UUID id;
+	 * 		private UUID articleId;
+	 * 		private String articleTitle;
+	 * 		private UUID userId;
+	 * 		private String userNickname;
+	 * 		private String content;
+	 * 		private Integer likeCount;
+	 * 		private Instant createdAt;
+	 */
+	public void saveMongoComment(UUID userId, Comment comment) {
+		int count = (int)commentLikeRepository.countByComment_Id(comment.getId());
+		MUserActivity.Comment buildComment = MUserActivity.Comment.builder()
+			.id(comment.getId())
+			.articleId(comment.getArticle().getId())
+			.articleTitle(comment.getArticle().getTitle())
+			.userId(userId)
+			.userNickname(comment.getUser().getNickname())
+			.content(comment.getContent())
+			.likeCount(count)
+			.createdAt(comment.getCreatedAt())
+			.build();
+
+		mUserActivityService.addComment(userId, buildComment);
+	}
 
 }

--- a/src/main/java/com/monew/monew_server/domain/interest/service/InterestService.java
+++ b/src/main/java/com/monew/monew_server/domain/interest/service/InterestService.java
@@ -1,5 +1,14 @@
 package com.monew.monew_server.domain.interest.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.monew.monew_server.domain.interest.dto.CursorPageResponseInterestDto;
 import com.monew.monew_server.domain.interest.dto.InterestDto;
 import com.monew.monew_server.domain.interest.dto.InterestQuery;
@@ -16,17 +25,13 @@ import com.monew.monew_server.domain.interest.repository.InterestRepository;
 import com.monew.monew_server.domain.interest.repository.SubscriptionRepository;
 import com.monew.monew_server.domain.user.entity.User;
 import com.monew.monew_server.domain.user.repository.UserRepository;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.MUserActivityService;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
 import com.monew.monew_server.exception.ErrorCode;
 import com.monew.monew_server.exception.InterestException;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -34,130 +39,144 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class InterestService {
 
-    private final InterestRepository interestRepository;
-    private final InterestKeywordRepository interestKeywordRepository;
-    private final SubscriptionRepository subscriptionRepository;
-    private final UserRepository userRepository;
+	private final InterestRepository interestRepository;
+	private final InterestKeywordRepository interestKeywordRepository;
+	private final SubscriptionRepository subscriptionRepository;
+	private final UserRepository userRepository;
+	private final MUserActivityService mUserActivityService;
 
-    private final InterestMapper interestMapper;
-    private final SubscriptionMapper subscriptionMapper;
+	private final InterestMapper interestMapper;
+	private final SubscriptionMapper subscriptionMapper;
 
-    public CursorPageResponseInterestDto findAll(InterestQuery query, UUID userId) {
-        return interestRepository.findAll(query, userId);
-    }
+	public CursorPageResponseInterestDto findAll(InterestQuery query, UUID userId) {
+		return interestRepository.findAll(query, userId);
+	}
 
-    @Transactional
-    public InterestDto create(InterestRegisterRequest request) {
-        String name = request.name();
-        List<String> keywords = request.keywords();
+	@Transactional
+	public InterestDto create(InterestRegisterRequest request) {
+		String name = request.name();
+		List<String> keywords = request.keywords();
 
-        List<Interest> similarInterests = interestRepository.findSimilarInterests(name);
-        if (!similarInterests.isEmpty()) {
-            throw new InterestException(
-                ErrorCode.INTEREST_NAME_DUPLICATION,
-                Map.of("name", name)
-            );
-        }
+		List<Interest> similarInterests = interestRepository.findSimilarInterests(name);
+		if (!similarInterests.isEmpty()) {
+			throw new InterestException(
+				ErrorCode.INTEREST_NAME_DUPLICATION,
+				Map.of("name", name)
+			);
+		}
 
-        Interest interest = interestRepository.save(
-            Interest.builder()
-                .name(name)
-                .build()
-        );
+		Interest interest = interestRepository.save(
+			Interest.builder()
+				.name(name)
+				.build()
+		);
 
-        List<InterestKeyword> interestKeywords = keywords.stream()
-            .map(keywordName -> InterestKeyword.builder()
-                .name(keywordName)
-                .interest(interest)
-                .build())
-            .collect(Collectors.toList());
+		List<InterestKeyword> interestKeywords = keywords.stream()
+			.map(keywordName -> InterestKeyword.builder()
+				.name(keywordName)
+				.interest(interest)
+				.build())
+			.collect(Collectors.toList());
 
-        List<InterestKeyword> savedKeywords = interestKeywordRepository.saveAll(interestKeywords);
+		List<InterestKeyword> savedKeywords = interestKeywordRepository.saveAll(interestKeywords);
 
-        List<String> savedKeywordNames = savedKeywords.stream()
-            .map(InterestKeyword::getName)
-            .toList();
+		List<String> savedKeywordNames = savedKeywords.stream()
+			.map(InterestKeyword::getName)
+			.toList();
 
-        return interestMapper.toDto(
-            interest,
-            savedKeywordNames,
-            0L,
-            null
-        );
-    }
+		return interestMapper.toDto(
+			interest,
+			savedKeywordNames,
+			0L,
+			null
+		);
+	}
 
-    @Transactional
-    public InterestDto update(UUID interestId, InterestUpdateRequest request) {
-        Interest interest = interestRepository.getOrThrow(interestId);
-        interestKeywordRepository.deleteAllByInterestId(interestId);
+	@Transactional
+	public InterestDto update(UUID interestId, InterestUpdateRequest request) {
+		Interest interest = interestRepository.getOrThrow(interestId);
+		interestKeywordRepository.deleteAllByInterestId(interestId);
 
-        List<String> newKeywordNames = request.keywords();
+		List<String> newKeywordNames = request.keywords();
 
-        List<InterestKeyword> newKeywords = newKeywordNames.stream()
-            .map(keywordName -> InterestKeyword.builder()
-                .name(keywordName)
-                .interest(interest)
-                .build())
-            .collect(Collectors.toList());
+		List<InterestKeyword> newKeywords = newKeywordNames.stream()
+			.map(keywordName -> InterestKeyword.builder()
+				.name(keywordName)
+				.interest(interest)
+				.build())
+			.collect(Collectors.toList());
 
-        interestKeywordRepository.saveAll(newKeywords);
+		interestKeywordRepository.saveAll(newKeywords);
 
-        long subscriberCount = subscriptionRepository.countByInterestId(interestId);
+		long subscriberCount = subscriptionRepository.countByInterestId(interestId);
 
-        return interestMapper.toDto(
-            interest,
-            newKeywordNames,
-            subscriberCount,
-            null
-        );
-    }
+		return interestMapper.toDto(
+			interest,
+			newKeywordNames,
+			subscriberCount,
+			null
+		);
+	}
 
-    @Transactional
-    public void delete(UUID interestId) {
-        interestRepository.getOrThrow(interestId);
-        interestRepository.deleteById(interestId);
-    }
+	@Transactional
+	public void delete(UUID interestId) {
+		interestRepository.getOrThrow(interestId);
+		interestRepository.deleteById(interestId);
+	}
 
-    @Transactional
-    public SubscriptionDto subscribe(UUID interestId, UUID userId) {
+	@Transactional
+	public SubscriptionDto subscribe(UUID interestId, UUID userId) {
 
-        if (!userRepository.existsById(userId)) {
-            throw new InterestException(ErrorCode.USER_NOT_FOUND);
-        }
+		if (!userRepository.existsById(userId)) {
+			throw new InterestException(ErrorCode.USER_NOT_FOUND);
+		}
 
-        Interest interest = interestRepository.getOrThrow(interestId);
+		Interest interest = interestRepository.getOrThrow(interestId);
 
-        Optional<Subscription> existingSubscription = subscriptionRepository
-            .findByUserIdAndInterestId(userId, interestId);
+		Optional<Subscription> existingSubscription = subscriptionRepository
+			.findByUserIdAndInterestId(userId, interestId);
 
-        Subscription subscription;
-        if (existingSubscription.isPresent()) {
-            subscription = existingSubscription.get();
-        } else {
-            User userProxy = userRepository.getReferenceById(userId);
+		Subscription subscription;
+		if (existingSubscription.isPresent()) {
+			subscription = existingSubscription.get();
+		} else {
+			User userProxy = userRepository.getReferenceById(userId);
 
-            Subscription newSubscription = Subscription.builder()
-                .user(userProxy)
-                .interest(interest)
-                .build();
+			Subscription newSubscription = Subscription.builder()
+				.user(userProxy)
+				.interest(interest)
+				.build();
 
-            subscription = subscriptionRepository.save(newSubscription);
-        }
+			subscription = subscriptionRepository.save(newSubscription);
+		}
 
-        List<String> keywords = interestKeywordRepository.findKeywordsByInterestId(interest.getId());
-        long subscriberCount = subscriptionRepository.countByInterestId(interest.getId());
-        return subscriptionMapper.toDto(subscription, keywords, subscriberCount);
-    }
+		List<String> keywords = interestKeywordRepository.findKeywordsByInterestId(interest.getId());
+		long subscriberCount = subscriptionRepository.countByInterestId(interest.getId());
 
+		MUserActivity.Subscription mongoSub = MUserActivity.Subscription.builder()
+			.id(userId)
+			.interestId(interestId)
+			.interestName(interest.getName())
+			.interestKeywords(keywords)
+			.interestSubscriberCount((int)subscriberCount)
+			.createdAt(subscription.getCreatedAt())
+			.build();
+		mUserActivityService.addSubscription(userId, mongoSub);
 
-    @Transactional
-    public void unsubscribe(UUID interestId, UUID userId) {
+		return subscriptionMapper.toDto(subscription, keywords, subscriberCount);
+	}
 
-        if (!userRepository.existsById(userId)) {
-            throw new InterestException(ErrorCode.USER_NOT_FOUND);
-        }
+	@Transactional
+	public void unsubscribe(UUID interestId, UUID userId) {
 
-        interestRepository.getOrThrow(interestId);
-        subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId);
-    }
+		if (!userRepository.existsById(userId)) {
+			throw new InterestException(ErrorCode.USER_NOT_FOUND);
+		}
+
+		interestRepository.getOrThrow(interestId);
+		subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId);
+
+		mUserActivityService.removeSubscription(userId, interestId);
+	}
+
 }

--- a/src/main/java/com/monew/monew_server/domain/user/service/UserService.java
+++ b/src/main/java/com/monew/monew_server/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.monew.monew_server.domain.user.service;
 
+import java.time.Instant;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -11,6 +12,8 @@ import com.monew.monew_server.domain.user.dto.UserRegisterRequest;
 import com.monew.monew_server.domain.user.dto.UserUpdateRequset;
 import com.monew.monew_server.domain.user.entity.User;
 import com.monew.monew_server.domain.user.repository.UserRepository;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.MUserActivityService;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final MUserActivityService userActivityService;
 
 	public void register(UserRegisterRequest request) {
 		// 이메일 중복 검사
@@ -39,11 +43,13 @@ public class UserService {
 			.password(request.getPassword())
 			.build();
 
-		userRepository.save(user);
+		User savedUser = userRepository.save(user);
+		addMongoUser(savedUser.getId(), savedUser.getEmail(), savedUser.getNickname(), savedUser.getCreatedAt());
+
 	}
 
 	@Transactional(readOnly = true)
-	public UserDto login (UserLoginRequest request) {
+	public UserDto login(UserLoginRequest request) {
 		User user = userRepository.findByEmail(request.getEmail())
 			.orElseThrow(() -> new IllegalArgumentException("올바르지 않는 이메일입니다."));
 
@@ -51,7 +57,7 @@ public class UserService {
 			throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
 		}
 
-		if (!user.getPassword().equals(request.getPassword())){
+		if (!user.getPassword().equals(request.getPassword())) {
 			throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
 		}
 
@@ -64,7 +70,7 @@ public class UserService {
 	}
 
 	@Transactional
-	public UserDto updateNickname (UUID userId, UserUpdateRequset requset) {
+	public UserDto updateNickname(UUID userId, UserUpdateRequset requset) {
 		// 유저 존재 확인
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
@@ -96,7 +102,7 @@ public class UserService {
 
 	@Transactional
 	public void deleteUser(UUID id) {
-		User user  = userRepository.findById(id)
+		User user = userRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
 
 		if (user.getDeletedAt() != null) {
@@ -104,5 +110,10 @@ public class UserService {
 		}
 
 		user.softDelete();
+	}
+
+	// mongoDB용
+	public MUserActivity addMongoUser(UUID userId, String email, String nickname, Instant createdAt) {
+		return userActivityService.initializeUserActivity(userId, email, nickname, createdAt);
 	}
 }

--- a/src/main/java/com/monew/monew_server/domain/user_activity/controller/UserActivityController.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/controller/UserActivityController.java
@@ -5,10 +5,12 @@ import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.monew.monew_server.domain.user_activity.dto.UserActivityDto;
+import com.monew.monew_server.domain.user_activity.service.DeNormalizeService;
 import com.monew.monew_server.domain.user_activity.service.UserActivityService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,11 +21,24 @@ import lombok.RequiredArgsConstructor;
 public class UserActivityController {
 
 	private final UserActivityService userActivityService;
+	private final DeNormalizeService syncService;
 
 	// 사용자 정보 조회
 	@GetMapping("/{userId}")
 	public ResponseEntity<UserActivityDto> getUserActivity(@PathVariable UUID userId) {
 		UserActivityDto userActivity = userActivityService.getUserActivity(userId);
 		return ResponseEntity.ok(userActivity);
+	}
+
+	@GetMapping("/{userId}/mongo")
+	public ResponseEntity<UserActivityDto> getUserActivityMongo(@PathVariable UUID userId) {
+		UserActivityDto userActivity = userActivityService.getMongo(userId);
+		return ResponseEntity.ok(userActivity);
+	}
+
+	// 성능 측정용
+	@PostMapping("/sync-all")
+	public void syncAll() {
+		syncService.syncAllUsers();
 	}
 }

--- a/src/main/java/com/monew/monew_server/domain/user_activity/mapper/UserActivityMapper.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/mapper/UserActivityMapper.java
@@ -1,14 +1,18 @@
 package com.monew.monew_server.domain.user_activity.mapper;
 
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
 import com.monew.monew_server.domain.user.entity.User;
 import com.monew.monew_server.domain.user_activity.dto.ArticleViewSummaryDto;
 import com.monew.monew_server.domain.user_activity.dto.CommentLikeSummaryDto;
 import com.monew.monew_server.domain.user_activity.dto.CommentSummaryDto;
 import com.monew.monew_server.domain.user_activity.dto.SubscriptionSummaryDto;
 import com.monew.monew_server.domain.user_activity.dto.UserActivityDto;
-import java.util.List;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
 
 @Mapper(componentModel = "spring")
 public interface UserActivityMapper {
@@ -28,4 +32,26 @@ public interface UserActivityMapper {
 		List<CommentLikeSummaryDto> commentLikes,
 		List<ArticleViewSummaryDto> articleViews
 	);
+
+	@Mapping(target = "id", source = "userId")
+	UserActivityDto toDto(MUserActivity mUserActivity);
+
+	@Mapping(target = "interestSubscriberCount", source = "interestSubscriberCount", qualifiedByName = "integerToLong")
+	SubscriptionSummaryDto toSubscriptionSummaryDto(MUserActivity.Subscription subscription);
+
+	@Mapping(target = "likeCount", source = "likeCount", qualifiedByName = "integerToLong")
+	CommentSummaryDto toCommentSummaryDto(MUserActivity.Comment comment);
+
+	@Mapping(target = "commentLikeCount", source = "commentLikeCount", qualifiedByName = "integerToLong")
+	CommentLikeSummaryDto toCommentLikeSummaryDto(MUserActivity.CommentLike commentLike);
+
+	@Mapping(target = "articleCommentCount", source = "articleCommentCount", qualifiedByName = "integerToLong")
+	@Mapping(target = "articleViewCount", source = "articleViewCount", qualifiedByName = "integerToLong")
+	ArticleViewSummaryDto toArticleViewSummaryDto(MUserActivity.ArticleView articleView);
+
+	@Named("integerToLong")
+	default long integerToLong(Integer value) {
+		return value != null ? value.longValue() : 0L;
+	}
+
 }

--- a/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityArticleViewRepository.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityArticleViewRepository.java
@@ -1,4 +1,4 @@
-package com.monew.monew_server.domain.user_activity.repository;
+package com.monew.monew_server.domain.user_activity.repository.jpa;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityCommentLikeCountRepository.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityCommentLikeCountRepository.java
@@ -1,4 +1,4 @@
-package com.monew.monew_server.domain.user_activity.repository;
+package com.monew.monew_server.domain.user_activity.repository.jpa;
 
 import java.util.UUID;
 
@@ -9,5 +9,5 @@ import com.monew.monew_server.domain.comment.entity.CommentLike;
 
 @Repository
 public interface UserActivityCommentLikeCountRepository extends JpaRepository<CommentLike, UUID> {
-	
+
 }

--- a/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityCommentLikeRepository.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityCommentLikeRepository.java
@@ -1,4 +1,4 @@
-package com.monew.monew_server.domain.user_activity.repository;
+package com.monew.monew_server.domain.user_activity.repository.jpa;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityCommentRepository.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityCommentRepository.java
@@ -1,4 +1,4 @@
-package com.monew.monew_server.domain.user_activity.repository;
+package com.monew.monew_server.domain.user_activity.repository.jpa;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityInterestKeywordRepository.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivityInterestKeywordRepository.java
@@ -1,4 +1,4 @@
-package com.monew.monew_server.domain.user_activity.repository;
+package com.monew.monew_server.domain.user_activity.repository.jpa;
 
 import java.util.List;
 import java.util.UUID;
@@ -12,3 +12,4 @@ import com.monew.monew_server.domain.interest.entity.InterestKeyword;
 public interface UserActivityInterestKeywordRepository extends JpaRepository<InterestKeyword, UUID> {
 	List<InterestKeyword> findByInterest_Id(UUID interestId);
 }
+

--- a/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivitySubscriptionRepository.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/repository/jpa/UserActivitySubscriptionRepository.java
@@ -1,4 +1,4 @@
-package com.monew.monew_server.domain.user_activity.repository;
+package com.monew.monew_server.domain.user_activity.repository.jpa;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/monew/monew_server/domain/user_activity/repository/mongodb/MUserActivityService.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/repository/mongodb/MUserActivityService.java
@@ -1,0 +1,94 @@
+package com.monew.monew_server.domain.user_activity.repository.mongodb;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.repository.MUserActivityRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MUserActivityService {
+
+	private static final int MAX_ARRAY_SIZE = 10;
+	private final MongoTemplate mongoTemplate;
+	private final MUserActivityRepository mUserActivityRepository;
+
+	public MUserActivity initializeUserActivity(UUID userId, String email, String nickname, Instant createdAt) {
+		MUserActivity userActivity = MUserActivity.builder()
+			.userId(userId)
+			.email(email)
+			.nickname(nickname)
+			.createdAt(createdAt)
+			.build();
+
+		return mUserActivityRepository.save(userActivity);
+	}
+
+	public void addSubscription(UUID userId, MUserActivity.Subscription subscription) {
+		Query query = new Query(Criteria.where("_id").is(userId));
+
+		Update update = new Update()
+			.push("subscriptions")
+			.atPosition(0)
+			.each(subscription);
+
+		mongoTemplate.updateFirst(query, update, MUserActivity.class);
+	}
+
+	public void removeSubscription(UUID userId, UUID interestId) {
+		Query query = new Query(Criteria.where("_id").is(userId));
+
+		Update update = new Update()
+			.pull("subscriptions", Query.query(Criteria.where("interestId").is(interestId)));
+
+		mongoTemplate.updateFirst(query, update, MUserActivity.class);
+	}
+
+	public void addComment(UUID userId, MUserActivity.Comment comment) {
+		Query query = new Query(Criteria.where("_id").is(userId));
+
+		Update update = new Update()
+			.push("comments")
+			.atPosition(0)
+			.slice(MAX_ARRAY_SIZE)
+			.each(comment);
+
+		mongoTemplate.updateFirst(query, update, MUserActivity.class);
+	}
+
+	public void addCommentLike(UUID userId, MUserActivity.CommentLike commentLike) {
+		Query query = new Query(Criteria.where("_id").is(userId));
+
+		Update update = new Update()
+			.push("commentLikes")
+			.atPosition(0)
+			.slice(MAX_ARRAY_SIZE)
+			.each(commentLike);
+
+		mongoTemplate.updateFirst(query, update, MUserActivity.class);
+	}
+
+	public void addArticleView(UUID userId, MUserActivity.ArticleView articleView) {
+		Query query = new Query(Criteria.where("_id").is(userId));
+
+		Update update = new Update()
+			.push("articleViews")
+			.atPosition(0)
+			.slice(MAX_ARRAY_SIZE)
+			.each(articleView);
+
+		mongoTemplate.updateFirst(query, update, MUserActivity.class);
+	}
+
+}

--- a/src/main/java/com/monew/monew_server/domain/user_activity/repository/mongodb/entity/MUserActivity.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/repository/mongodb/entity/MUserActivity.java
@@ -1,0 +1,89 @@
+package com.monew.monew_server.domain.user_activity.repository.mongodb.entity;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Document(collection = "user_activity")
+@Data
+@Builder
+public class MUserActivity {
+
+	@Id
+	private UUID userId;
+
+	private String email;
+	private String nickname;
+	private Instant createdAt;
+
+	@Builder.Default
+	private List<Subscription> subscriptions = new ArrayList<>();
+	@Builder.Default
+	private List<Comment> comments = new ArrayList<>();
+	@Builder.Default
+	private List<CommentLike> commentLikes = new ArrayList<>();
+	@Builder.Default
+	private List<ArticleView> articleViews = new ArrayList<>();
+
+	@Data
+	@Builder
+	public static class Subscription {
+		private UUID id;
+		private UUID interestId;
+		private String interestName;
+		private List<String> interestKeywords;
+		private Integer interestSubscriberCount;
+		private Instant createdAt;
+	}
+
+	@Data
+	@Builder
+	public static class Comment {
+		private UUID id;
+		private UUID articleId;
+		private String articleTitle;
+		private UUID userId;
+		private String userNickname;
+		private String content;
+		private Integer likeCount;
+		private Instant createdAt;
+	}
+
+	@Data
+	@Builder
+	public static class CommentLike {
+		private UUID id;
+		private Instant createdAt;
+		private UUID commentId;
+		private UUID articleId;
+		private String articleTitle;
+		private UUID commentUserId;
+		private String commentUserNickname;
+		private String commentContent;
+		private Integer commentLikeCount;
+		private Instant commentCreatedAt;
+	}
+
+	@Data
+	@Builder
+	public static class ArticleView {
+		private UUID id;
+		private UUID viewedBy;
+		private Instant createdAt;
+		private UUID articleId;
+		private String source;
+		private String sourceUrl;
+		private String articleTitle;
+		private Instant articlePublishedDate;
+		private String articleSummary;
+		private Integer articleCommentCount;
+		private Integer articleViewCount;
+	}
+}

--- a/src/main/java/com/monew/monew_server/domain/user_activity/repository/mongodb/repository/MUserActivityRepository.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/repository/mongodb/repository/MUserActivityRepository.java
@@ -1,0 +1,15 @@
+package com.monew.monew_server.domain.user_activity.repository.mongodb.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
+
+@Repository
+public interface MUserActivityRepository extends MongoRepository<MUserActivity, UUID> {
+
+	MUserActivity findByUserId(UUID userId);
+
+}

--- a/src/main/java/com/monew/monew_server/domain/user_activity/service/DeNormalizeService.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/service/DeNormalizeService.java
@@ -1,0 +1,253 @@
+package com.monew.monew_server.domain.user_activity.service;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.stereotype.Service;
+
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeNormalizeService {
+
+	private final JdbcTemplate jdbcTemplate;
+	private final MongoTemplate mongoTemplate;
+
+	/**
+	 * 전체 사용자 MongoDB로 밀어넣기
+	 */
+	public void syncAllUsers() {
+		jdbcTemplate.query("SELECT id FROM users", new RowCallbackHandler() {
+			@Override
+			public void processRow(ResultSet rs) throws SQLException {
+				UUID userId = UUID.fromString(rs.getString("id"));
+				syncUser(userId);
+			}
+		});
+	}
+
+	/**
+	 * 단일 사용자만 동기화
+	 */
+	public void syncUser(UUID userId) {
+		// 1. user
+		UserRow user = jdbcTemplate.query("""
+			SELECT id, email, nickname, created_at
+			FROM users
+			WHERE id = ?
+			""", rs -> rs.next()
+			? new UserRow(
+			UUID.fromString(rs.getString("id")),
+			rs.getString("email"),
+			rs.getString("nickname"),
+			rs.getTimestamp("created_at").toInstant()
+		)
+			: null, userId);
+
+		if (user == null) {
+			return;
+		}
+
+		// 2. build doc
+		MUserActivity doc = MUserActivity.builder()
+			.userId(user.id())
+			.email(user.email())
+			.nickname(user.nickname())
+			.createdAt(user.createdAt())
+			.subscriptions(fetchSubscriptions(userId))
+			.comments(fetchComments(userId))
+			.commentLikes(fetchCommentLikes(userId))
+			.articleViews(fetchArticleViews(userId))
+			.build();
+
+		// 3. save
+		mongoTemplate.save(doc);
+	}
+
+	private List<MUserActivity.Subscription> fetchSubscriptions(UUID userId) {
+		List<Map<String, Object>> rows = jdbcTemplate.queryForList("""
+			SELECT
+			    s.id               AS subscription_id,
+			    s.created_at       AS subscription_created_at,
+			    i.id               AS interest_id,
+			    i.name             AS interest_name,
+			    ik.name            AS keyword_name,
+			    cnt.subscriber_cnt AS subscriber_cnt
+			FROM subscriptions s
+			JOIN interests i ON s.interest_id = i.id
+			LEFT JOIN interest_keywords ik ON ik.interest_id = i.id
+			LEFT JOIN (
+			    SELECT interest_id, COUNT(*) AS subscriber_cnt
+			    FROM subscriptions
+			    GROUP BY interest_id
+			) cnt ON cnt.interest_id = i.id
+			WHERE s.user_id = ?
+			ORDER BY s.created_at DESC
+			LIMIT 50
+			""", userId);
+
+		Map<UUID, MUserActivity.Subscription> map = new LinkedHashMap<>();
+		for (Map<String, Object> row : rows) {
+			UUID subId = (UUID)row.get("subscription_id");
+			MUserActivity.Subscription sub = map.get(subId);
+			if (sub == null) {
+				Number cnt = (Number)row.get("subscriber_cnt");   // ← 핵심
+				sub = MUserActivity.Subscription.builder()
+					.id(subId)
+					.interestId((UUID)row.get("interest_id"))
+					.interestName((String)row.get("interest_name"))
+					.interestKeywords(new ArrayList<>())
+					.interestSubscriberCount(cnt == null ? 0 : cnt.intValue())
+					.createdAt(toInstant(row.get("subscription_created_at")))
+					.build();
+				map.put(subId, sub);
+			}
+			String keyword = (String)row.get("keyword_name");
+			if (keyword != null) {
+				sub.getInterestKeywords().add(keyword);
+			}
+		}
+		return new ArrayList<>(map.values());
+	}
+
+	private List<MUserActivity.Comment> fetchComments(UUID userId) {
+		return jdbcTemplate.query("""
+			SELECT
+			    c.id         AS comment_id,
+			    c.article_id AS article_id,
+			    a.title      AS article_title,
+			    c.user_id    AS user_id,
+			    u.nickname   AS user_nickname,
+			    c.content    AS content,
+			    c.created_at AS created_at,
+			    COALESCE(cl.cnt, 0) AS like_count
+			FROM comments c
+			JOIN articles a ON c.article_id = a.id
+			JOIN users u ON c.user_id = u.id
+			LEFT JOIN (
+			    SELECT comment_id, COUNT(*) AS cnt
+			    FROM comment_likes
+			    GROUP BY comment_id
+			) cl ON cl.comment_id = c.id
+			WHERE c.user_id = ?
+			ORDER BY c.created_at DESC
+			LIMIT 50
+			""", (rs, n) -> MUserActivity.Comment.builder()
+			.id(UUID.fromString(rs.getString("comment_id")))
+			.articleId(UUID.fromString(rs.getString("article_id")))
+			.articleTitle(rs.getString("article_title"))
+			.userId(UUID.fromString(rs.getString("user_id")))
+			.userNickname(rs.getString("user_nickname"))
+			.content(rs.getString("content"))
+			.likeCount(rs.getInt("like_count"))
+			.createdAt(rs.getTimestamp("created_at").toInstant())
+			.build(), userId);
+	}
+
+	private List<MUserActivity.CommentLike> fetchCommentLikes(UUID userId) {
+		return jdbcTemplate.query("""
+			SELECT
+			    cl.id         AS like_id,
+			    cl.created_at AS like_created_at,
+			    c.id          AS comment_id,
+			    c.content     AS comment_content,
+			    c.created_at  AS comment_created_at,
+			    c.user_id     AS comment_user_id,
+			    u.nickname    AS comment_user_nickname,
+			    a.id          AS article_id,
+			    a.title       AS article_title,
+			    COALESCE(clcnt.cnt, 0) AS comment_like_count
+			FROM comment_likes cl
+			JOIN comments c ON cl.comment_id = c.id
+			JOIN users u ON c.user_id = u.id
+			JOIN articles a ON c.article_id = a.id
+			LEFT JOIN (
+			    SELECT comment_id, COUNT(*) AS cnt
+			    FROM comment_likes
+			    GROUP BY comment_id
+			) clcnt ON clcnt.comment_id = c.id
+			WHERE cl.user_id = ?
+			ORDER BY cl.created_at DESC
+			LIMIT 50
+			""", (rs, n) -> MUserActivity.CommentLike.builder()
+			.id(UUID.fromString(rs.getString("like_id")))
+			.createdAt(rs.getTimestamp("like_created_at").toInstant())
+			.commentId(UUID.fromString(rs.getString("comment_id")))
+			.articleId(UUID.fromString(rs.getString("article_id")))
+			.articleTitle(rs.getString("article_title"))
+			.commentUserId(UUID.fromString(rs.getString("comment_user_id")))
+			.commentUserNickname(rs.getString("comment_user_nickname"))
+			.commentContent(rs.getString("comment_content"))
+			.commentLikeCount(rs.getInt("comment_like_count"))
+			.commentCreatedAt(rs.getTimestamp("comment_created_at").toInstant())
+			.build(), userId);
+	}
+
+	private List<MUserActivity.ArticleView> fetchArticleViews(UUID userId) {
+		return jdbcTemplate.query("""
+			SELECT
+			    av.id          AS view_id,
+			    av.created_at  AS view_created_at,
+			    av.user_id     AS viewed_by,
+			    a.id           AS article_id,
+			    a.source       AS source,
+			    a.source_url   AS source_url,
+			    a.title        AS article_title,
+			    a.publish_date AS article_published_date,
+			    a.summary      AS article_summary,
+			    COALESCE(cmt.cnt, 0)   AS article_comment_count,
+			    COALESCE(avcnt.cnt, 0) AS article_view_count
+			FROM article_views av
+			JOIN articles a ON av.article_id = a.id
+			LEFT JOIN (
+			    SELECT article_id, COUNT(*) AS cnt
+			    FROM comments
+			    GROUP BY article_id
+			) cmt ON cmt.article_id = a.id
+			LEFT JOIN (
+			    SELECT article_id, COUNT(*) AS cnt
+			    FROM article_views
+			    GROUP BY article_id
+			) avcnt ON avcnt.article_id = a.id
+			WHERE av.user_id = ?
+			ORDER BY av.created_at DESC
+			LIMIT 50
+			""", (rs, n) -> MUserActivity.ArticleView.builder()
+			.id(UUID.fromString(rs.getString("view_id")))
+			.viewedBy(UUID.fromString(rs.getString("viewed_by")))
+			.createdAt(rs.getTimestamp("view_created_at").toInstant())
+			.articleId(UUID.fromString(rs.getString("article_id")))
+			.source(rs.getString("source"))
+			.sourceUrl(rs.getString("source_url"))
+			.articleTitle(rs.getString("article_title"))
+			.articlePublishedDate(rs.getTimestamp("article_published_date").toInstant())
+			.articleSummary(rs.getString("article_summary"))
+			.articleCommentCount(rs.getInt("article_comment_count"))
+			.articleViewCount(rs.getInt("article_view_count"))
+			.build(), userId);
+	}
+
+	private Instant toInstant(Object o) {
+		if (o == null)
+			return null;
+		if (o instanceof Timestamp ts)
+			return ts.toInstant();
+		return null;
+	}
+
+	private record UserRow(UUID id, String email, String nickname, Instant createdAt) {
+	}
+}

--- a/src/main/java/com/monew/monew_server/domain/user_activity/service/UserActivityService.java
+++ b/src/main/java/com/monew/monew_server/domain/user_activity/service/UserActivityService.java
@@ -1,5 +1,11 @@
 package com.monew.monew_server.domain.user_activity.service;
 
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.monew.monew_server.domain.article.entity.Article;
 import com.monew.monew_server.domain.interest.entity.InterestKeyword;
 import com.monew.monew_server.domain.user.entity.User;
@@ -10,19 +16,18 @@ import com.monew.monew_server.domain.user_activity.dto.CommentSummaryDto;
 import com.monew.monew_server.domain.user_activity.dto.SubscriptionSummaryDto;
 import com.monew.monew_server.domain.user_activity.dto.UserActivityDto;
 import com.monew.monew_server.domain.user_activity.mapper.UserActivityMapper;
-import com.monew.monew_server.domain.user_activity.repository.UserActivityArticleViewRepository;
-import com.monew.monew_server.domain.user_activity.repository.UserActivityCommentLikeRepository;
-import com.monew.monew_server.domain.user_activity.repository.UserActivityCommentRepository;
-import com.monew.monew_server.domain.user_activity.repository.UserActivityInterestKeywordRepository;
-import com.monew.monew_server.domain.user_activity.repository.UserActivitySubscriptionRepository;
+import com.monew.monew_server.domain.user_activity.repository.jpa.UserActivityArticleViewRepository;
+import com.monew.monew_server.domain.user_activity.repository.jpa.UserActivityCommentLikeRepository;
+import com.monew.monew_server.domain.user_activity.repository.jpa.UserActivityCommentRepository;
+import com.monew.monew_server.domain.user_activity.repository.jpa.UserActivityInterestKeywordRepository;
+import com.monew.monew_server.domain.user_activity.repository.jpa.UserActivitySubscriptionRepository;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.entity.MUserActivity;
+import com.monew.monew_server.domain.user_activity.repository.mongodb.repository.MUserActivityRepository;
 import com.monew.monew_server.exception.ErrorCode;
 import com.monew.monew_server.exception.UserActivityException;
-import java.util.List;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -37,18 +42,16 @@ public class UserActivityService {
 	private final UserActivityArticleViewRepository userActivityArticleViewRepository;
 	private final UserActivityInterestKeywordRepository userActivityInterestKeywordRepository;
 
-	/**
-	 * 사용자 전체 활동 조회
-	 */
+	private final MUserActivityRepository mUserActivityRepository;
 
 	@Transactional(readOnly = true)
 	public UserActivityDto getUserActivity(UUID userId) {
 		log.info("[UserActivityService] 사용자 활동 조회 요청 - userId={}", userId);
 
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new UserActivityException(ErrorCode.USER_NOT_FOUND));
+		User user =
+			userRepository
+				.findById(userId)
+				.orElseThrow(() -> new UserActivityException(ErrorCode.USER_NOT_FOUND));
 
 		// 구독 중인 관심사 10개 조회
 		List<SubscriptionSummaryDto> subscriptions = userActivitySubscriptionRepository
@@ -106,7 +109,6 @@ public class UserActivityService {
 			.map(cl -> {
 				UUID commentId = cl.getComment().getId();
 
-
 				long likeCount = userActivityCommentLikeRepository.countByComment_Id(commentId);
 
 				return CommentLikeSummaryDto.builder()
@@ -148,10 +150,9 @@ public class UserActivityService {
 					.articleCommentCount(commentCount)
 					.articleViewCount(viewCount)
 					.build();
-				})
-				.toList();
+			})
+			.toList();
 		log.debug("[UserActivityService] 기사 조회 {}건 완료", articleViews.size());
-
 
 		UserActivityDto result = userActivityMapper.toDto(
 			user,
@@ -167,4 +168,13 @@ public class UserActivityService {
 
 		return result;
 	}
+
+	public UserActivityDto getMongo(UUID userId) {
+		MUserActivity mUserActivity = mUserActivityRepository.findByUserId(userId);
+		if (mUserActivity == null) {
+			throw new UserActivityException(ErrorCode.USER_NOT_FOUND);
+		}
+		return userActivityMapper.toDto(mUserActivity);
+	}
+
 }

--- a/src/test/java/com/monew/monew_server/domain/interest/repository/InterestQueryRepositoryImplTest.java
+++ b/src/test/java/com/monew/monew_server/domain/interest/repository/InterestQueryRepositoryImplTest.java
@@ -1,17 +1,9 @@
 package com.monew.monew_server.domain.interest.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
-import com.monew.monew_server.domain.interest.dto.CursorPageResponseInterestDto;
-import com.monew.monew_server.domain.interest.dto.InterestQuery;
-import com.monew.monew_server.domain.interest.entity.Interest;
-import com.monew.monew_server.domain.interest.entity.InterestKeyword;
-import com.monew.monew_server.domain.interest.entity.Subscription;
-import com.monew.monew_server.domain.user.entity.User;
-import com.monew.monew_server.domain.user.repository.UserRepository;
-import jakarta.persistence.EntityManager;
 import java.time.Instant;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,380 +17,393 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import com.monew.monew_server.domain.interest.dto.CursorPageResponseInterestDto;
+import com.monew.monew_server.domain.interest.dto.InterestQuery;
+import com.monew.monew_server.domain.interest.entity.Interest;
+import com.monew.monew_server.domain.interest.entity.InterestKeyword;
+import com.monew.monew_server.domain.interest.entity.Subscription;
+import com.monew.monew_server.domain.user.entity.User;
+import com.monew.monew_server.domain.user.repository.UserRepository;
+
+import jakarta.persistence.EntityManager;
+
 @SpringBootTest
 @Testcontainers
 @Transactional
 class InterestQueryRepositoryImplTest {
 
-    @Container
-    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15-alpine");
+	@Container
+	static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15-alpine");
+	@Autowired
+	private InterestQueryRepositoryImpl interestQueryRepository;
+	@Autowired
+	private InterestRepository interestRepository;
+	@Autowired
+	private InterestKeywordRepository interestKeywordRepository;
+	@Autowired
+	private SubscriptionRepository subscriptionRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private EntityManager entityManager;
+	private User user1;
+	private Interest iReact;
+	private Interest iJava;
+	private Interest iSpring;
 
-    @DynamicPropertySource
-    static void postgresqlProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
-        registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
-        registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
-        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
-    }
+	@DynamicPropertySource
+	static void postgresqlProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
+		registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
+		registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
 
-    @Autowired private InterestQueryRepositoryImpl interestQueryRepository;
+	/**
+	 * 테스트 데이터 설정:
+	 * - Order (Name DESC): Spring -> React -> Java -> Docker
+	 * - Order (SubCount DESC): Java(2) -> Spring(1) -> Docker(0) -> React(0)
+	 * - Tie-Breaker (SubCount=0, createdAt DESC): Docker -> React (Docker가 더 최신)
+	 * - User1 구독: Java, Spring
+	 */
+	@BeforeEach
+	void setUp() throws InterruptedException {
+		// 데이터 초기화 (외래키 제약조건 순서 고려)
+		subscriptionRepository.deleteAll();
+		interestKeywordRepository.deleteAll();
+		interestRepository.deleteAll();
+		userRepository.deleteAll();
 
-    @Autowired private InterestRepository interestRepository;
-    @Autowired private InterestKeywordRepository interestKeywordRepository;
-    @Autowired private SubscriptionRepository subscriptionRepository;
-    @Autowired private UserRepository userRepository;
-    @Autowired private EntityManager entityManager;
+		// 1. 유저 생성
+		user1 = userRepository.save(User.builder()
+			.email("test@test.com")
+			.nickname("test")
+			.password("test1234!")
+			.build()
+		);
+		User user2 = userRepository.save(User.builder()
+			.email("test2@test.com")
+			.nickname("test2")
+			.password("test1234!")
+			.build()
+		);
 
-    private User user1;
-    private Interest iReact;
-    private Interest iJava;
-    private Interest iSpring;
+		// 2. 관심사 생성 (createdAt 순서 보장을 위해 sleep)
+		iReact = interestRepository.save(Interest.builder().name("React").build());   // 0 subs
+		Thread.sleep(10);
+		iJava = interestRepository.save(Interest.builder().name("Java").build());    // 2 subs
+		Thread.sleep(10);
+		iSpring = interestRepository.save(Interest.builder().name("Spring").build());  // 1 sub
+		Thread.sleep(10);
+		interestRepository.save(Interest.builder().name("Docker").build());  // 0 subs (React보다 최신)
 
-    /**
-     * 테스트 데이터 설정:
-     * - Order (Name DESC): Spring -> React -> Java -> Docker
-     * - Order (SubCount DESC): Java(2) -> Spring(1) -> Docker(0) -> React(0)
-     * - Tie-Breaker (SubCount=0, createdAt DESC): Docker -> React (Docker가 더 최신)
-     * - User1 구독: Java, Spring
-     */
-    @BeforeEach
-    void setUp() throws InterruptedException {
-        // 데이터 초기화 (외래키 제약조건 순서 고려)
-        subscriptionRepository.deleteAll();
-        interestKeywordRepository.deleteAll();
-        interestRepository.deleteAll();
-        userRepository.deleteAll();
+		// 3. 키워드 생성
+		interestKeywordRepository.save(InterestKeyword.builder().name("Boot").interest(iSpring).build());
+		interestKeywordRepository.save(InterestKeyword.builder().name("JVM").interest(iJava).build());
+		interestKeywordRepository.save(InterestKeyword.builder().name("Web").interest(iReact).build());
 
-        // 1. 유저 생성
-        user1 = userRepository.save(User.builder()
-            .email("test@test.com")
-            .nickname("test")
-            .password("test1234!")
-            .build()
-        );
-        User user2 = userRepository.save(User.builder()
-            .email("test2@test.com")
-            .nickname("test2")
-            .password("test1234!")
-            .build()
-        );
+		// 4. 구독 정보 생성
+		subscriptionRepository.save(Subscription.builder().user(user1).interest(iJava).build());
+		subscriptionRepository.save(Subscription.builder().user(user2).interest(iJava).build()); // Java: 2
+		subscriptionRepository.save(Subscription.builder().user(user1).interest(iSpring).build()); // Spring: 1
 
-        // 2. 관심사 생성 (createdAt 순서 보장을 위해 sleep)
-        iReact = interestRepository.save(Interest.builder().name("React").build());   // 0 subs
-        Thread.sleep(10);
-        iJava = interestRepository.save(Interest.builder().name("Java").build());    // 2 subs
-        Thread.sleep(10);
-        iSpring = interestRepository.save(Interest.builder().name("Spring").build());  // 1 sub
-        Thread.sleep(10);
-        interestRepository.save(Interest.builder().name("Docker").build());  // 0 subs (React보다 최신)
+		// 5. 영속성 컨텍스트 초기화 (N+1 및 서브쿼리 정확도)
+		entityManager.flush();
+		entityManager.clear();
+	}
 
-        // 3. 키워드 생성
-        interestKeywordRepository.save(InterestKeyword.builder().name("Boot").interest(iSpring).build());
-        interestKeywordRepository.save(InterestKeyword.builder().name("JVM").interest(iJava).build());
-        interestKeywordRepository.save(InterestKeyword.builder().name("Web").interest(iReact).build());
+	// --- 1. 기본 조회 및 페이징 테스트 ---
 
-        // 4. 구독 정보 생성
-        subscriptionRepository.save(Subscription.builder().user(user1).interest(iJava).build());
-        subscriptionRepository.save(Subscription.builder().user(user2).interest(iJava).build()); // Java: 2
-        subscriptionRepository.save(Subscription.builder().user(user1).interest(iSpring).build()); // Spring: 1
+	@Test
+	@DisplayName("findAll: 1페이지 조회 (기본값: 이름 DESC, limit 2)")
+	void findAll_Page1_DefaultSort_NameDesc() {
+		// given
+		InterestQuery query = new InterestQuery(null, null, null, null, null, 2, null, null);
 
-        // 5. 영속성 컨텍스트 초기화 (N+1 및 서브쿼리 정확도)
-        entityManager.flush();
-        entityManager.clear();
-    }
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-    // --- 1. 기본 조회 및 페이징 테스트 ---
+		// then
+		assertThat(response.totalElements()).isEqualTo(4);
+		assertThat(response.hasNext()).isTrue();
+		assertThat(response.content()).hasSize(2);
+		// 이름 DESC: Spring -> React -> Java -> Docker
+		assertThat(response.content().get(0).name()).isEqualTo("Spring");
+		assertThat(response.content().get(1).name()).isEqualTo("React");
+	}
 
-    @Test
-    @DisplayName("findAll: 1페이지 조회 (기본값: 이름 DESC, limit 2)")
-    void findAll_Page1_DefaultSort_NameDesc() {
-        // given
-        InterestQuery query = new InterestQuery(null, null, null, null, null, 2, null, null);
+	@Test
+	@DisplayName("findAll: 2페이지 조회 (이름 DESC, 커서 사용)")
+	void findAll_Page2_NameDesc_WithCursor() {
+		// given: 1페이지의 마지막(React) 정보를 커서로 사용
+		InterestQuery query = new InterestQuery(
+			null, "name", "DESC", "React", iReact.getCreatedAt(), 2, null, null
+		);
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // then
-        assertThat(response.totalElements()).isEqualTo(4);
-        assertThat(response.hasNext()).isTrue();
-        assertThat(response.content()).hasSize(2);
-        // 이름 DESC: Spring -> React -> Java -> Docker
-        assertThat(response.content().get(0).name()).isEqualTo("Spring");
-        assertThat(response.content().get(1).name()).isEqualTo("React");
-    }
+		// then: 마지막 페이지
+		assertThat(response.totalElements()).isEqualTo(4);
+		assertThat(response.hasNext()).isFalse();
+		assertThat(response.content()).hasSize(2);
+		// 2페이지: Java -> Docker
+		assertThat(response.content().get(0).name()).isEqualTo("Java");
+		assertThat(response.content().get(1).name()).isEqualTo("Docker");
+		assertThat(response.nextCursor()).isNull();
+		assertThat(response.nextAfter()).isNull();
+	}
+	// --- 2. 정렬(ASC/DESC) 및 Tie-Breaker 테스트 ---
 
-    @Test
-    @DisplayName("findAll: 2페이지 조회 (이름 DESC, 커서 사용)")
-    void findAll_Page2_NameDesc_WithCursor() {
-        // given: 1페이지의 마지막(React) 정보를 커서로 사용
-        InterestQuery query = new InterestQuery(
-            null, "name", "DESC", "React", iReact.getCreatedAt(), 2, null, null
-        );
+	@Test
+	@DisplayName("findAll: 구독자순 DESC 1페이지 조회")
+	void findAll_Page1_SubCountDesc() {
+		// given
+		InterestQuery query = new InterestQuery(
+			null, "subscriberCount", "DESC", null, null, 2, null, null
+		);
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // then: 마지막 페이지
-        assertThat(response.totalElements()).isEqualTo(4);
-        assertThat(response.hasNext()).isFalse();
-        assertThat(response.content()).hasSize(2);
-        // 2페이지: Java -> Docker
-        assertThat(response.content().get(0).name()).isEqualTo("Java");
-        assertThat(response.content().get(1).name()).isEqualTo("Docker");
-        assertThat(response.nextCursor()).isNull();
-        assertThat(response.nextAfter()).isNull();
-    }
-    // --- 2. 정렬(ASC/DESC) 및 Tie-Breaker 테스트 ---
+		// then
+		// SubCount DESC: Java(2) -> Spring(1) -> Docker(0) -> React(0)
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.content().get(0).name()).isEqualTo("Java"); // 2 subs
+		assertThat(response.content().get(1).name()).isEqualTo("Spring"); // 1 sub
+		assertThat(response.hasNext()).isTrue();
 
-    @Test
-    @DisplayName("findAll: 구독자순 DESC 1페이지 조회")
-    void findAll_Page1_SubCountDesc() {
-        // given
-        InterestQuery query = new InterestQuery(
-            null, "subscriberCount", "DESC", null, null, 2, null, null
-        );
+		// 커서 정보 (last element = Spring)
+		assertThat(response.nextCursor()).isEqualTo("1"); // subscriberCount
+		// assertThat(response.nextAfter()).isEqualTo(iSpring.getCreatedAt());
+	}
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+	@Test
+	@DisplayName("findAll: 구독자순 DESC 2페이지 조회 (Tie-Breaker: createdAt DESC)")
+	void findAll_Page2_SubCountDesc_WithTieBreaker() {
+		// given: 1페이지 마지막(Spring) 커서
+		InterestQuery query = new InterestQuery(
+			null, "subscriberCount", "DESC", "1", iSpring.getCreatedAt(), 2, null, null
+		);
 
-        // then
-        // SubCount DESC: Java(2) -> Spring(1) -> Docker(0) -> React(0)
-        assertThat(response.content()).hasSize(2);
-        assertThat(response.content().get(0).name()).isEqualTo("Java"); // 2 subs
-        assertThat(response.content().get(1).name()).isEqualTo("Spring"); // 1 sub
-        assertThat(response.hasNext()).isTrue();
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // 커서 정보 (last element = Spring)
-        assertThat(response.nextCursor()).isEqualTo("1"); // subscriberCount
-        assertThat(response.nextAfter()).isEqualTo(iSpring.getCreatedAt());
-    }
+		// then
+		// 2페이지: Docker(0) -> React(0) (Docker가 React보다 최신(createdAt DESC))
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.content().get(0).name()).isEqualTo("Docker");
+		assertThat(response.content().get(1).name()).isEqualTo("React");
+		assertThat(response.hasNext()).isFalse();
+	}
 
-    @Test
-    @DisplayName("findAll: 구독자순 DESC 2페이지 조회 (Tie-Breaker: createdAt DESC)")
-    void findAll_Page2_SubCountDesc_WithTieBreaker() {
-        // given: 1페이지 마지막(Spring) 커서
-        InterestQuery query = new InterestQuery(
-            null, "subscriberCount", "DESC", "1", iSpring.getCreatedAt(), 2, null, null
-        );
+	@Test
+	@DisplayName("findAll: 이름 ASC 1페이지 조회")
+	void findAll_Page1_NameAsc() {
+		// given
+		InterestQuery query = new InterestQuery(
+			null, "name", "ASC", null, null, 2, null, null
+		);
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // then
-        // 2페이지: Docker(0) -> React(0) (Docker가 React보다 최신(createdAt DESC))
-        assertThat(response.content()).hasSize(2);
-        assertThat(response.content().get(0).name()).isEqualTo("Docker");
-        assertThat(response.content().get(1).name()).isEqualTo("React");
-        assertThat(response.hasNext()).isFalse();
-    }
+		// then
+		// 이름 ASC: Docker -> Java -> React -> Spring
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.content().get(0).name()).isEqualTo("Docker");
+		assertThat(response.content().get(1).name()).isEqualTo("Java");
+		assertThat(response.hasNext()).isTrue();
+	}
 
-    @Test
-    @DisplayName("findAll: 이름 ASC 1페이지 조회")
-    void findAll_Page1_NameAsc() {
-        // given
-        InterestQuery query = new InterestQuery(
-            null, "name", "ASC", null, null, 2, null, null
-        );
+	@Test
+	@DisplayName("findAll: 2페이지 조회 (이름 ASC, 커서 사용)")
+	void findAll_Page2_NameAsc_WithCursor() {
+		// given: 이름 ASC 정렬: Docker -> Java -> React -> Spring
+		// 1페이지(limit 2)는 Docker, Java.
+		// 1페이지의 마지막(Java) 정보를 커서로 사용
+		InterestQuery query = new InterestQuery(
+			null, "name", "ASC", "Java", iJava.getCreatedAt(), 2, null, null
+		);
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // then
-        // 이름 ASC: Docker -> Java -> React -> Spring
-        assertThat(response.content()).hasSize(2);
-        assertThat(response.content().get(0).name()).isEqualTo("Docker");
-        assertThat(response.content().get(1).name()).isEqualTo("Java");
-        assertThat(response.hasNext()).isTrue();
-    }
+		// then: 마지막 페이지
+		assertThat(response.totalElements()).isEqualTo(4);
+		assertThat(response.hasNext()).isFalse();
+		assertThat(response.content()).hasSize(2);
+		// 2페이지: React -> Spring
+		assertThat(response.content().get(0).name()).isEqualTo("React");
+		assertThat(response.content().get(1).name()).isEqualTo("Spring");
+	}
 
-    @Test
-    @DisplayName("findAll: 2페이지 조회 (이름 ASC, 커서 사용)")
-    void findAll_Page2_NameAsc_WithCursor() {
-        // given: 이름 ASC 정렬: Docker -> Java -> React -> Spring
-        // 1페이지(limit 2)는 Docker, Java.
-        // 1페이지의 마지막(Java) 정보를 커서로 사용
-        InterestQuery query = new InterestQuery(
-            null, "name", "ASC", "Java", iJava.getCreatedAt(), 2, null, null
-        );
+	@Test
+	@DisplayName("findAll: 2페이지 조회 (구독자순 ASC, 커서 사용)")
+	void findAll_Page2_SubCountAsc_WithCursor() {
+		// given: 구독자순 ASC: Docker(0, 최신) -> React(0, 이전) -> Spring(1) -> Java(2)
+		// (0개짜리 Tie-breaker는 createdAt DESC이므로, createdAt이 느린(최신) Docker가 먼저 옴)
+		// 1페이지(limit 2)는 React, Docker.
+		// 1페이지의 마지막(Docker) 정보를 커서로 사용
+		InterestQuery query = new InterestQuery(
+			null, "subscriberCount", "ASC", "0", iReact.getCreatedAt(), 2, null, null
+		);
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // then: 마지막 페이지
-        assertThat(response.totalElements()).isEqualTo(4);
-        assertThat(response.hasNext()).isFalse();
-        assertThat(response.content()).hasSize(2);
-        // 2페이지: React -> Spring
-        assertThat(response.content().get(0).name()).isEqualTo("React");
-        assertThat(response.content().get(1).name()).isEqualTo("Spring");
-    }
+		// then: 마지막 페이지
+		assertThat(response.totalElements()).isEqualTo(4);
+		assertThat(response.hasNext()).isFalse();
+		assertThat(response.content()).hasSize(2);
+		// 2페이지: Spring(1) -> Java(2)
+		assertThat(response.content().get(0).name()).isEqualTo("Spring");
+		assertThat(response.content().get(1).name()).isEqualTo("Java");
+		assertThat(response.content().get(0).subscriberCount()).isEqualTo(1L);
+		assertThat(response.content().get(1).subscriberCount()).isEqualTo(2L);
+	}
 
-    @Test
-    @DisplayName("findAll: 2페이지 조회 (구독자순 ASC, 커서 사용)")
-    void findAll_Page2_SubCountAsc_WithCursor() {
-        // given: 구독자순 ASC: Docker(0, 최신) -> React(0, 이전) -> Spring(1) -> Java(2)
-        // (0개짜리 Tie-breaker는 createdAt DESC이므로, createdAt이 느린(최신) Docker가 먼저 옴)
-        // 1페이지(limit 2)는 React, Docker.
-        // 1페이지의 마지막(Docker) 정보를 커서로 사용
-        InterestQuery query = new InterestQuery(
-            null, "subscriberCount", "ASC", "0", iReact.getCreatedAt(), 2, null, null
-        );
+	// --- 3. 필터링(buildKeywordFilter) 테스트 ---
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+	@Test
+	@DisplayName("findAll: 키워드 필터링 (Interest.name 매칭)")
+	void findAll_Filter_byInterestName() {
+		// given
+		InterestQuery query = new InterestQuery("Java", null, null, null, null, 10, null, null);
 
-        // then: 마지막 페이지
-        assertThat(response.totalElements()).isEqualTo(4);
-        assertThat(response.hasNext()).isFalse();
-        assertThat(response.content()).hasSize(2);
-        // 2페이지: Spring(1) -> Java(2)
-        assertThat(response.content().get(0).name()).isEqualTo("Spring");
-        assertThat(response.content().get(1).name()).isEqualTo("Java");
-        assertThat(response.content().get(0).subscriberCount()).isEqualTo(1L);
-        assertThat(response.content().get(1).subscriberCount()).isEqualTo(2L);
-    }
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-    // --- 3. 필터링(buildKeywordFilter) 테스트 ---
+		// then
+		assertThat(response.totalElements()).isEqualTo(1);
+		assertThat(response.content()).hasSize(1);
+		assertThat(response.content().get(0).name()).isEqualTo("Java");
+	}
 
-    @Test
-    @DisplayName("findAll: 키워드 필터링 (Interest.name 매칭)")
-    void findAll_Filter_byInterestName() {
-        // given
-        InterestQuery query = new InterestQuery("Java", null, null, null, null, 10, null, null);
+	@Test
+	@DisplayName("findAll: 키워드 필터링 (InterestKeyword.name 매칭)")
+	void findAll_Filter_byKeywordName() {
+		// given
+		InterestQuery query = new InterestQuery("Boot", null, null, null, null, 10, null, null);
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // then
-        assertThat(response.totalElements()).isEqualTo(1);
-        assertThat(response.content()).hasSize(1);
-        assertThat(response.content().get(0).name()).isEqualTo("Java");
-    }
+		// then (Batch Fetch 로직 검증)
+		assertThat(response.totalElements()).isEqualTo(1); // "Spring"
+		assertThat(response.content()).hasSize(1);
+		assertThat(response.content().get(0).name()).isEqualTo("Spring");
+		assertThat(response.content().get(0).keywords()).contains("Boot");
+	}
 
-    @Test
-    @DisplayName("findAll: 키워드 필터링 (InterestKeyword.name 매칭)")
-    void findAll_Filter_byKeywordName() {
-        // given
-        InterestQuery query = new InterestQuery("Boot", null, null, null, null, 10, null, null);
+	@Test
+	@DisplayName("findAll: 키워드 필터링 (결과 없음)")
+	void findAll_Filter_NoResults() {
+		// given
+		InterestQuery query = new InterestQuery("NonExistent", null, null, null, null, 10, null, null);
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // then (Batch Fetch 로직 검증)
-        assertThat(response.totalElements()).isEqualTo(1); // "Spring"
-        assertThat(response.content()).hasSize(1);
-        assertThat(response.content().get(0).name()).isEqualTo("Spring");
-        assertThat(response.content().get(0).keywords()).contains("Boot");
-    }
+		// then (keywordsMap.isEmpty() 분기 커버)
+		assertThat(response.totalElements()).isZero();
+		assertThat(response.content()).isEmpty();
+		assertThat(response.hasNext()).isFalse();
+	}
 
-    @Test
-    @DisplayName("findAll: 키워드 필터링 (결과 없음)")
-    void findAll_Filter_NoResults() {
-        // given
-        InterestQuery query = new InterestQuery("NonExistent", null, null, null, null, 10, null, null);
+	// --- 4. 엣지 케이스 및 분기 커버리지 ---
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+	@Test
+	@DisplayName("findAll: 비로그인(userId=null) 시 'subscribedByMe'는 항상 false")
+	void findAll_LoggedOut_SubscribedByMeIsFalse() {
+		// given: 1페이지 (Spring, React), userId = null
+		InterestQuery query = new InterestQuery(null, null, null, null, null, 2, null, null);
 
-        // then (keywordsMap.isEmpty() 분기 커버)
-        assertThat(response.totalElements()).isZero();
-        assertThat(response.content()).isEmpty();
-        assertThat(response.hasNext()).isFalse();
-    }
+		// when
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, null);
 
-    // --- 4. 엣지 케이스 및 분기 커버리지 ---
+		// then
+		// user1은 Spring을 구독했지만, userId=null이므로 false여야 함
+		assertThat(response.content().get(0).name()).isEqualTo("Spring");
+		assertThat(response.content().get(0).subscribedByMe()).isFalse();
+		// user1이 구독 안 한 React도 false
+		assertThat(response.content().get(1).name()).isEqualTo("React");
+		assertThat(response.content().get(1).subscribedByMe()).isFalse();
+	}
 
-    @Test
-    @DisplayName("findAll: 비로그인(userId=null) 시 'subscribedByMe'는 항상 false")
-    void findAll_LoggedOut_SubscribedByMeIsFalse() {
-        // given: 1페이지 (Spring, React), userId = null
-        InterestQuery query = new InterestQuery(null, null, null, null, null, 2, null, null);
+	@Test
+	@DisplayName("buildRangeFromCursor: 구독자순 정렬 시 잘못된 커서(숫자 아님) 예외")
+	void buildRangeFromCursor_InvalidCursor_ThrowsException() {
+		// given: orderBy=subscriberCount, cursor="not-a-number"
+		InterestQuery query = new InterestQuery(
+			null, "subscriberCount", "DESC", "not-a-number", Instant.now(), 10, null, null
+		);
 
-        // when
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, null);
+		// when & then (IllegalArgumentException 분기 커버)
+		assertThatThrownBy(() -> interestQueryRepository.findAll(query, user1.getId()))
+			.isInstanceOf(InvalidDataAccessApiUsageException.class)
+			.hasMessageContaining("invalid cursor: not-a-number")
+			.hasRootCauseInstanceOf(IllegalArgumentException.class);
+	}
 
-        // then
-        // user1은 Spring을 구독했지만, userId=null이므로 false여야 함
-        assertThat(response.content().get(0).name()).isEqualTo("Spring");
-        assertThat(response.content().get(0).subscribedByMe()).isFalse();
-        // user1이 구독 안 한 React도 false
-        assertThat(response.content().get(1).name()).isEqualTo("React");
-        assertThat(response.content().get(1).subscribedByMe()).isFalse();
-    }
+	@Test
+	@DisplayName("findAll: 'after'가 null이고 'cursor'만 있으면 1페이지로 동작")
+	void findAll_WhenAfterIsNull_ShouldActAsPage1() {
+		// given
+		// 2페이지 커서("React")가 있지만, after(createdAt)가 null
+		InterestQuery query = new InterestQuery(
+			null, "name", "DESC", "React", null, 2, null, null
+		);
 
-    @Test
-    @DisplayName("buildRangeFromCursor: 구독자순 정렬 시 잘못된 커서(숫자 아님) 예외")
-    void buildRangeFromCursor_InvalidCursor_ThrowsException() {
-        // given: orderBy=subscriberCount, cursor="not-a-number"
-        InterestQuery query = new InterestQuery(
-            null, "subscriberCount", "DESC", "not-a-number", Instant.now(), 10, null, null
-        );
+		// when
+		// buildRangeFromCursor가 (after == null) 조건 때문에 null을 반환해야 함
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // when & then (IllegalArgumentException 분기 커버)
-        assertThatThrownBy(() -> interestQueryRepository.findAll(query, user1.getId()))
-            .isInstanceOf(InvalidDataAccessApiUsageException.class)
-            .hasMessageContaining("invalid cursor: not-a-number")
-            .hasRootCauseInstanceOf(IllegalArgumentException.class);
-    }
+		// then
+		// 2페이지(Java, Docker)가 아닌 1페이지(Spring, React)가 나와야 함
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.content().get(0).name()).isEqualTo("Spring");
+		assertThat(response.content().get(1).name()).isEqualTo("React");
+		assertThat(response.hasNext()).isTrue();
+	}
 
-    @Test
-    @DisplayName("findAll: 'after'가 null이고 'cursor'만 있으면 1페이지로 동작")
-    void findAll_WhenAfterIsNull_ShouldActAsPage1() {
-        // given
-        // 2페이지 커서("React")가 있지만, after(createdAt)가 null
-        InterestQuery query = new InterestQuery(
-            null, "name", "DESC", "React", null, 2, null, null
-        );
+	@Test
+	@DisplayName("findAll: 'cursor'가 null이고 'after'만 있으면 1페이지로 동작")
+	void findAll_WhenCursorIsNull_ShouldActAsPage1() {
+		// given
+		// 2페이지 after(iReact.getCreatedAt())가 있지만, cursor가 null
+		InterestQuery query = new InterestQuery(
+			null, "name", "DESC", null, iReact.getCreatedAt(), 2, null, null
+		);
 
-        // when
-        // buildRangeFromCursor가 (after == null) 조건 때문에 null을 반환해야 함
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+		// when
+		// buildRangeFromCursor가 (!hasText(cursor)) 조건 때문에 null을 반환해야 함
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // then
-        // 2페이지(Java, Docker)가 아닌 1페이지(Spring, React)가 나와야 함
-        assertThat(response.content()).hasSize(2);
-        assertThat(response.content().get(0).name()).isEqualTo("Spring");
-        assertThat(response.content().get(1).name()).isEqualTo("React");
-        assertThat(response.hasNext()).isTrue();
-    }
+		// then
+		// 1페이지(Spring, React)가 나와야 함
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.content().get(0).name()).isEqualTo("Spring");
+		assertThat(response.content().get(1).name()).isEqualTo("React");
+	}
 
-    @Test
-    @DisplayName("findAll: 'cursor'가 null이고 'after'만 있으면 1페이지로 동작")
-    void findAll_WhenCursorIsNull_ShouldActAsPage1() {
-        // given
-        // 2페이지 after(iReact.getCreatedAt())가 있지만, cursor가 null
-        InterestQuery query = new InterestQuery(
-            null, "name", "DESC", null, iReact.getCreatedAt(), 2, null, null
-        );
+	@Test
+	@DisplayName("findAll: 'cursor'가 빈 문자열이면 1페이지로 동작")
+	void findAll_WhenCursorIsEmptyString_ShouldActAsPage1() {
+		// given
+		// 2페이지 after(iReact.getCreatedAt())가 있지만, cursor가 "" (empty string)
+		InterestQuery query = new InterestQuery(
+			null, "name", "DESC", "", iReact.getCreatedAt(), 2, null, null
+		);
 
-        // when
-        // buildRangeFromCursor가 (!hasText(cursor)) 조건 때문에 null을 반환해야 함
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
+		// when
+		// buildRangeFromCursor가 (!hasText(cursor)) 조건 때문에 null을 반환해야 함
+		CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
 
-        // then
-        // 1페이지(Spring, React)가 나와야 함
-        assertThat(response.content()).hasSize(2);
-        assertThat(response.content().get(0).name()).isEqualTo("Spring");
-        assertThat(response.content().get(1).name()).isEqualTo("React");
-    }
-
-    @Test
-    @DisplayName("findAll: 'cursor'가 빈 문자열이면 1페이지로 동작")
-    void findAll_WhenCursorIsEmptyString_ShouldActAsPage1() {
-        // given
-        // 2페이지 after(iReact.getCreatedAt())가 있지만, cursor가 "" (empty string)
-        InterestQuery query = new InterestQuery(
-            null, "name", "DESC", "", iReact.getCreatedAt(), 2, null, null
-        );
-
-        // when
-        // buildRangeFromCursor가 (!hasText(cursor)) 조건 때문에 null을 반환해야 함
-        CursorPageResponseInterestDto response = interestQueryRepository.findAll(query, user1.getId());
-
-        // then
-        // 1페이지(Spring, React)가 나와야 함
-        assertThat(response.content()).hasSize(2);
-        assertThat(response.content().get(0).name()).isEqualTo("Spring");
-        assertThat(response.content().get(1).name()).isEqualTo("React");
-    }
+		// then
+		// 1페이지(Spring, React)가 나와야 함
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.content().get(0).name()).isEqualTo("Spring");
+		assertThat(response.content().get(1).name()).isEqualTo("React");
+	}
 }


### PR DESCRIPTION
## PR 요약
mongoDB 적용 및 성능 테스트

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#83 )
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료

## 상세 설명
mongodb 적용했습니다.
   -  user가 회원가입할 때 활동 기록을 저장하기 위한 mongodb document도 동시에 추가하도록 하였습니다.
   -  article, comment, interest 등에 저장, 삭제를 할때마다  document도 동시에 수정되도록하였습니다.
성능측정을 하였습니다.
   -  파이썬의 locust를 활용하여 성능을 측정하였음
      
<img width="1415" height="312" alt="스크린샷 2025-11-05 21-37-45" src="https://github.com/user-attachments/assets/fea4d6a9-acab-46ad-9060-096f5cf33074" />
<img width="1406" height="840" alt="스크린샷 2025-11-05 20-15-44" src="https://github.com/user-attachments/assets/b1805686-82a8-4111-9d63-46de3b94780d" />

## 검증 단계
-  적용 후 로컬 프론트에서도 정상 동작함을 확인하였습니다.
-  위의 사진을 보면 대략 20000번 정도의 호출해도 fail이 0임을 확인할 수 있습니다.
